### PR TITLE
[Feat] 코어 데이터 모델 추가

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4491DFEC2ADD4CF800CA5B42 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFEB2ADD4CF800CA5B42 /* Persistence.swift */; };
+		4491DFEF2ADD4D4700CA5B42 /* Blank.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFED2ADD4D4700CA5B42 /* Blank.xcdatamodeld */; };
+		4491DFF32ADD4EEB00CA5B42 /* PersistenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFF22ADD4EEB00CA5B42 /* PersistenceView.swift */; };
 		ACDBDA5D2AD7CC7600C44A80 /* BlankApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDBDA5C2AD7CC7600C44A80 /* BlankApp.swift */; };
 		ACDBDA5F2AD7CC7600C44A80 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDBDA5E2AD7CC7600C44A80 /* ContentView.swift */; };
 		ACDBDA612AD7CC7700C44A80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACDBDA602AD7CC7700C44A80 /* Assets.xcassets */; };
@@ -19,6 +22,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		4491DFEB2ADD4CF800CA5B42 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
+		4491DFEE2ADD4D4700CA5B42 /* Blank.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Blank.xcdatamodel; sourceTree = "<group>"; };
+		4491DFF22ADD4EEB00CA5B42 /* PersistenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceView.swift; sourceTree = "<group>"; };
 		ACDBDA592AD7CC7600C44A80 /* Blank.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Blank.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ACDBDA5C2AD7CC7600C44A80 /* BlankApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankApp.swift; sourceTree = "<group>"; };
 		ACDBDA5E2AD7CC7600C44A80 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -42,6 +48,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4491DFEA2ADD4CCF00CA5B42 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				4491DFEB2ADD4CF800CA5B42 /* Persistence.swift */,
+				4491DFED2ADD4D4700CA5B42 /* Blank.xcdatamodeld */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
 		ACDBDA502AD7CC7600C44A80 = {
 			isa = PBXGroup;
 			children = (
@@ -61,6 +76,7 @@
 		ACDBDA5B2AD7CC7600C44A80 /* Blank */ = {
 			isa = PBXGroup;
 			children = (
+				4491DFEA2ADD4CCF00CA5B42 /* CoreData */,
 				ACF338BE2ADD00B7004D20FC /* View */,
 				ACF338BD2ADD00B1004D20FC /* Model */,
 				ACF338BC2ADD00A4004D20FC /* ViewModel */,
@@ -102,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				ACDBDA5E2AD7CC7600C44A80 /* ContentView.swift */,
+				4491DFF22ADD4EEB00CA5B42 /* PersistenceView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -177,11 +194,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				ACF338C42ADD0158004D20FC /* Session.swift in Sources */,
+				4491DFEC2ADD4CF800CA5B42 /* Persistence.swift in Sources */,
 				ACDBDA5F2AD7CC7600C44A80 /* ContentView.swift in Sources */,
 				ACF338C02ADD00DC004D20FC /* File.swift in Sources */,
 				ACF338C22ADD0136004D20FC /* Page.swift in Sources */,
 				ACF338C82ADD0327004D20FC /* del.swift in Sources */,
+				4491DFEF2ADD4D4700CA5B42 /* Blank.xcdatamodeld in Sources */,
 				ACDBDA5D2AD7CC7600C44A80 /* BlankApp.swift in Sources */,
+				4491DFF32ADD4EEB00CA5B42 /* PersistenceView.swift in Sources */,
 				ACF338C62ADD0172004D20FC /* Word.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -398,6 +418,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		4491DFED2ADD4D4700CA5B42 /* Blank.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				4491DFEE2ADD4D4700CA5B42 /* Blank.xcdatamodel */,
+			);
+			currentVersion = 4491DFEE2ADD4D4700CA5B42 /* Blank.xcdatamodel */;
+			path = Blank.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = ACDBDA512AD7CC7600C44A80 /* Project object */;
 }

--- a/Blank/Blank/BlankApp.swift
+++ b/Blank/Blank/BlankApp.swift
@@ -9,9 +9,15 @@ import SwiftUI
 
 @main
 struct BlankApp: App {
+    let persistenceController = PersistenceController.shared
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(
+                    \.managedObjectContext,
+                     persistenceController.container.viewContext
+                )
         }
     }
 }

--- a/Blank/Blank/CoreData/Blank.xcdatamodeld/Blank.xcdatamodel/contents
+++ b/Blank/Blank/CoreData/Blank.xcdatamodeld/Blank.xcdatamodel/contents
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22222" systemVersion="22G91" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+    </entity>
+</model>

--- a/Blank/Blank/CoreData/Persistence.swift
+++ b/Blank/Blank/CoreData/Persistence.swift
@@ -1,0 +1,58 @@
+//
+//  Persistence.swift
+//  Blank
+//
+//  Created by 윤범태 on 2023/10/16.
+//
+
+import CoreData
+
+struct PersistenceController {
+    static let shared = PersistenceController()
+
+    /// 코어데이터 미리보기 용도로 Item 엔티티 생성
+    static var preview: PersistenceController = {
+        let result = PersistenceController(inMemory: true)
+        let viewContext = result.container.viewContext
+        for _ in 0..<10 {
+            let newItem = Item(context: viewContext)
+            newItem.timestamp = Date()
+        }
+        do {
+            try viewContext.save()
+        } catch {
+            // Replace this implementation with code to handle the error appropriately.
+            // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+            let nsError = error as NSError
+            fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+        }
+        return result
+    }()
+
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "Blank")
+        if inMemory {
+            container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+
+                /*
+                 Typical reasons for an error here include:
+                 * The parent directory does not exist, cannot be created, or disallows writing.
+                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
+                 * The device is out of space.
+                 * The store could not be migrated to the current model version.
+                 Check the error message to determine what the actual problem was.
+                 */
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+}
+

--- a/Blank/Blank/View/PersistenceView.swift
+++ b/Blank/Blank/View/PersistenceView.swift
@@ -1,0 +1,93 @@
+//
+//  PersistenceView.swift
+//  Blank
+//
+//  Created by 윤범태 on 2023/10/16.
+//
+
+import SwiftUI
+import CoreData
+
+/*
+  코어데이터 설치 여부를 확인하기 위한 임시 뷰로 확인 완료되면 삭제할 예정입니다.
+ */
+struct PersistenceView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Item.timestamp, ascending: true)],
+        animation: .default)
+    private var items: FetchedResults<Item>
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(items) { item in
+                    NavigationLink {
+                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
+                    } label: {
+                        Text(item.timestamp!, formatter: itemFormatter)
+                    }
+                }
+                .onDelete(perform: deleteItems)
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    EditButton()
+                }
+                ToolbarItem {
+                    Button(action: addItem) {
+                        Label("Add Item", systemImage: "plus")
+                    }
+                }
+            }
+            Text("Select an item")
+        }
+    }
+
+    private func addItem() {
+        withAnimation {
+            let newItem = Item(context: viewContext)
+            newItem.timestamp = Date()
+
+            do {
+                try viewContext.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nsError = error as NSError
+                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+            }
+        }
+    }
+
+    private func deleteItems(offsets: IndexSet) {
+        withAnimation {
+            offsets.map { items[$0] }.forEach(viewContext.delete)
+
+            do {
+                try viewContext.save()
+            } catch {
+                // Replace this implementation with code to handle the error appropriately.
+                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                let nsError = error as NSError
+                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+            }
+        }
+    }
+}
+
+private let itemFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .short
+    formatter.timeStyle = .medium
+    return formatter
+}()
+
+#Preview {
+    PersistenceView()
+        .environment(
+            \.managedObjectContext,
+             PersistenceController.preview.container.viewContext
+        )
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
코어 데이터 초기화 및 모델을 추가했습니다.

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 코어 데이터 모델 생성
- 코어 데이터 관리 컨트롤러 (`PersistenceController`) 추가

## 주요 로직(Optional)
```diff
+ struct PersistenceController {...}
```

## 관련 이슈
- #10 