### PR TITLE
[Feat] PinchZoom view 추가

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		ACF338C42ADD0158004D20FC /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C32ADD0158004D20FC /* Session.swift */; };
 		ACF338C62ADD0172004D20FC /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C52ADD0172004D20FC /* Word.swift */; };
 		ACF338C82ADD0327004D20FC /* del.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C72ADD0327004D20FC /* del.swift */; };
+		EBEB72622AE0BC8500316D66 /* ImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBEB72612AE0BC8500316D66 /* ImageView.swift */; };
+		EBEB72642AE0BCA800316D66 /* PinchZoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBEB72632AE0BCA800316D66 /* PinchZoomView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -76,6 +78,8 @@
 		ACF338C32ADD0158004D20FC /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		ACF338C52ADD0172004D20FC /* Word.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Word.swift; sourceTree = "<group>"; };
 		ACF338C72ADD0327004D20FC /* del.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = del.swift; sourceTree = "<group>"; };
+		EBEB72612AE0BC8500316D66 /* ImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageView.swift; sourceTree = "<group>"; };
+		EBEB72632AE0BCA800316D66 /* PinchZoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinchZoomView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -213,6 +217,8 @@
 				449CB1D72ADED6920086758A /* Home */,
 				4491DFF22ADD4EEB00CA5B42 /* PersistenceView.swift */,
 				42ED60D72ADE7F910043AF2F /* PDFThumbnailView.swift */,
+				EBEB72612AE0BC8500316D66 /* ImageView.swift */,
+				EBEB72632AE0BCA800316D66 /* PinchZoomView.swift */,
 				42ED60C72ADE7EF50043AF2F /* OverView.swift */,
 				42ED60C92ADE7F090043AF2F /* OverViewModalView.swift */,
 				42ED60CB2ADE7F1A0043AF2F /* WordSelectView.swift */,
@@ -299,6 +305,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EBEB72642AE0BCA800316D66 /* PinchZoomView.swift in Sources */,
 				4491DFF82ADECF7F00CA5B42 /* FileMananger+.swift in Sources */,
 				42ED60D02ADE7F380043AF2F /* ScribbleModalView.swift in Sources */,
 				ACF338C42ADD0158004D20FC /* Session.swift in Sources */,
@@ -323,6 +330,7 @@
 				ACDBDA5D2AD7CC7600C44A80 /* BlankApp.swift in Sources */,
 				4491DFF32ADD4EEB00CA5B42 /* PersistenceView.swift in Sources */,
 				4491DFF92ADECF7F00CA5B42 /* UIImage+.swift in Sources */,
+				EBEB72622AE0BC8500316D66 /* ImageView.swift in Sources */,
 				42ED60D62ADE7F6C0043AF2F /* CorrectInfoView.swift in Sources */,
 				ACF338C62ADD0172004D20FC /* Word.swift in Sources */,
 			);

--- a/Blank/Blank/View/ImageView.swift
+++ b/Blank/Blank/View/ImageView.swift
@@ -1,0 +1,34 @@
+//
+//  ImageView.swift
+//  Blank
+//
+//  Created by 조용현 on 10/19/23.
+//
+
+import SwiftUI
+
+struct ImageView: View {
+    var image: String = ""
+    @Binding var scale: CGFloat
+
+    var body: some View {
+        GeometryReader { proxy in
+            // ScrollView를 통해 PinchZoom시 좌우상하 이동
+            ScrollView([.horizontal, .vertical]) {
+                Image(image)
+                    .resizable()
+                // GeometryReader를 통해 화면크기에 맞게 이미지 사이즈 조정
+                    .frame(width: proxy.size.width * scale, height: proxy.size.height * scale)
+                    .scaledToFit()
+                    .clipShape(Rectangle())
+                    .overlay {
+                        // TODO: Image 위에 올릴 컴포넌트(핀치줌 시 크기고정을 위해 width, height, x, y에 scale갑 곱하기)
+                    }
+            }
+        }
+    }
+}
+
+#Preview {
+    ImageView(scale: .constant(1.0))
+}

--- a/Blank/Blank/View/PinchZoomView.swift
+++ b/Blank/Blank/View/PinchZoomView.swift
@@ -1,0 +1,60 @@
+//
+//  PinchZoomView.swift
+//  Blank
+//
+//  Created by 조용현 on 10/19/23.
+//
+
+import SwiftUI
+
+import SwiftUI
+
+struct PinchZoomView: View {
+    @State private var scale: CGFloat = 1.0
+    @State var lastScale: CGFloat = 1.0
+    private let minScale = 1.0
+    private let maxScale = 5.0
+
+    var magnification: some Gesture {
+        // PinchZoom Gesture
+        MagnificationGesture()
+        // 확대 시작 시
+            .onChanged { state in
+                adjustScale(from: state)
+            }
+        // 확대 종료 시
+            .onEnded { state in
+                withAnimation {
+                    validateScaleLimits()
+                }
+                lastScale = 1.0
+            }
+    }
+
+    var body: some View {
+        // ImageView를 불러와서 Gesture 적용
+        ImageView(scale: $scale)
+            .gesture(magnification)
+    }
+    // 변경값을 lastScale에 저장하여 다음 확대시 lastScale에서부터 시작
+    func adjustScale(from state: MagnificationGesture.Value) {
+        let delta = state / lastScale
+        scale *= delta
+        lastScale = state
+    }
+    func getMinimumScaleAllowed() -> CGFloat {
+        return max(scale, minScale)
+    }
+    func getMaximumScaleAllowed() -> CGFloat {
+        return min(scale, maxScale)
+    }
+    // 확대 Scale min(1.0), max(3.0) 설정
+    func validateScaleLimits() {
+        scale = getMinimumScaleAllowed()
+        scale = getMaximumScaleAllowed()
+    }
+}
+
+#Preview {
+    PinchZoomView()
+}


### PR DESCRIPTION
## 개요 및 관련 이슈

- ImageView
  - Image 및 컴포넌트(TextField, Button 등)을 올리는 View
- PinchZoomView 
  - PinchZoom 기능을 적용한 View 
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

## 주요 로직(Optional)
```swift
var magnification: some Gesture {
        // PinchZoom Gesture
        MagnificationGesture()
        // 확대 시작 시
            .onChanged { state in
                adjustScale(from: state)
            }
        // 확대 종료 시
            .onEnded { state in
                withAnimation {
                    validateScaleLimits()
                }
                lastScale = 1.0
            }
    }
```
