### PR TITLE
[Design][Feat] 모든뷰 이미지로 수정 및 scrollview 기능 추가

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		42E7638A2AE1229700624D81 /* OverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E763892AE1229700624D81 /* OverViewModel.swift */; };
+		42E7638C2AE122D700624D81 /* CurrentPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E7638B2AE122D700624D81 /* CurrentPageView.swift */; };
+		42E7638E2AE1234A00624D81 /* samplepdf.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 42E7638D2AE1234A00624D81 /* samplepdf.pdf */; };
 		42ED60C62ADE7EDB0043AF2F /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42ED60C52ADE7EDB0043AF2F /* HomeView.swift */; };
 		42ED60C82ADE7EF50043AF2F /* OverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42ED60C72ADE7EF50043AF2F /* OverView.swift */; };
 		42ED60CA2ADE7F090043AF2F /* OverViewModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42ED60C92ADE7F090043AF2F /* OverViewModalView.swift */; };
@@ -44,6 +47,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		42E763892AE1229700624D81 /* OverViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverViewModel.swift; sourceTree = "<group>"; };
+		42E7638B2AE122D700624D81 /* CurrentPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentPageView.swift; sourceTree = "<group>"; };
+		42E7638D2AE1234A00624D81 /* samplepdf.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = samplepdf.pdf; sourceTree = "<group>"; };
 		42ED60C52ADE7EDB0043AF2F /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		42ED60C72ADE7EF50043AF2F /* OverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverView.swift; sourceTree = "<group>"; };
 		42ED60C92ADE7F090043AF2F /* OverViewModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverViewModalView.swift; sourceTree = "<group>"; };
@@ -178,6 +184,7 @@
 				ACF338BC2ADD00A4004D20FC /* ViewModel */,
 				ACDBDA5C2AD7CC7600C44A80 /* BlankApp.swift */,
 				ACDBDA602AD7CC7700C44A80 /* Assets.xcassets */,
+				42E7638D2AE1234A00624D81 /* samplepdf.pdf */,
 				ACDBDA622AD7CC7700C44A80 /* Preview Content */,
 			);
 			path = Blank;
@@ -196,6 +203,7 @@
 			children = (
 				ACF338C72ADD0327004D20FC /* del.swift */,
 				4491DFA92ADD1E2E00CA5B42 /* HomeViewModel.swift */,
+				42E763892AE1229700624D81 /* OverViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -220,6 +228,7 @@
 				EBEB72612AE0BC8500316D66 /* ImageView.swift */,
 				EBEB72632AE0BCA800316D66 /* PinchZoomView.swift */,
 				42ED60C72ADE7EF50043AF2F /* OverView.swift */,
+				42E7638B2AE122D700624D81 /* CurrentPageView.swift */,
 				42ED60C92ADE7F090043AF2F /* OverViewModalView.swift */,
 				42ED60CB2ADE7F1A0043AF2F /* WordSelectView.swift */,
 				42ED60CD2ADE7F290043AF2F /* OCREditView.swift */,
@@ -294,6 +303,7 @@
 				ACDBDA642AD7CC7700C44A80 /* Preview Assets.xcassets in Resources */,
 				449CB1E02ADEDAD00086758A /* horizontal.pdf in Resources */,
 				ACDBDA612AD7CC7700C44A80 /* Assets.xcassets in Resources */,
+				42E7638E2AE1234A00624D81 /* samplepdf.pdf in Resources */,
 				449CB1E32ADEDAD00086758A /* toeic.pdf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -324,9 +334,11 @@
 				ACF338C82ADD0327004D20FC /* del.swift in Sources */,
 				4491DFEF2ADD4D4700CA5B42 /* Blank.xcdatamodeld in Sources */,
 				449CB1DA2ADED6C10086758A /* DocumentPickerRepresentedView.swift in Sources */,
+				42E7638A2AE1229700624D81 /* OverViewModel.swift in Sources */,
 				42ED60D22ADE7F450043AF2F /* TestPageView.swift in Sources */,
 				42ED60CC2ADE7F1A0043AF2F /* WordSelectView.swift in Sources */,
 				42ED60D42ADE7F570043AF2F /* ResultPageView.swift in Sources */,
+				42E7638C2AE122D700624D81 /* CurrentPageView.swift in Sources */,
 				ACDBDA5D2AD7CC7600C44A80 /* BlankApp.swift in Sources */,
 				4491DFF32ADD4EEB00CA5B42 /* PersistenceView.swift in Sources */,
 				4491DFF92ADECF7F00CA5B42 /* UIImage+.swift in Sources */,

--- a/Blank/Blank/BlankApp.swift
+++ b/Blank/Blank/BlankApp.swift
@@ -13,9 +13,13 @@ struct BlankApp: App {
     
     @StateObject var homeViewModel = HomeViewModel()
     
+    init() {
+        HomeViewModel.copySampleFiles()
+    }
+    
     var body: some Scene {
         WindowGroup {
-            HomeView()
+            HomeView(overViewModel: OverViewModel())
                 .environment(
                     \.managedObjectContext,
                      persistenceController.container.viewContext

--- a/Blank/Blank/View/ContentView.swift
+++ b/Blank/Blank/View/ContentView.swift
@@ -1,0 +1,86 @@
+//
+//  ContentView.swift
+//  MacroView
+//
+//  Created by Greed on 10/14/23.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    @State var searchQueryString = ""
+    
+    var body: some View {
+        NavigationStack {
+            VStack {
+                thumbGridView
+            }
+            .searchable( // TODO: 서치기능
+                text: $searchQueryString,
+                placement: .navigationBarDrawer,
+                prompt: "Search"
+            )
+            .toolbar {
+                ToolbarItem(placement: .navigation) {
+                    editBtn
+                }
+                
+                ToolbarItem {
+                    fileBtn
+                }
+            }
+            .toolbarBackground(.white, for: .navigationBar)
+            .toolbarBackground(.visible, for: .navigationBar)
+            .navigationTitle("문서")
+            .navigationBarTitleDisplayMode(.inline)
+            .padding()
+            .navigationBarBackButtonHidden(true)
+        }
+    }
+    
+    private var thumbGridView: some View {
+        let item = GridItem(.adaptive(minimum: 225, maximum: 225), spacing: 30)
+        let columns = Array(repeating: item, count: 3)
+        return ScrollView {
+            LazyVGrid(columns: columns) {
+                ForEach(0..<10) {_ in
+                    NavigationLink(destination: OverView()) {
+                        // TODO: 전체페이지와 시험본 페이지를 각 카드뷰에 넘겨주기
+                        PDFThumbnailView()
+                    }
+                    .foregroundColor(.black)
+                }
+            }
+        }
+    }
+    
+    private var fileBtn: some View {
+        Menu {
+            Button {
+                // TODO: 파일 보관함 기능
+            } label: {
+                Text("파일 보관함")
+            }
+            Button {
+                // TODO: 사진 보관함 기능
+            } label: {
+                Text("사진 보관함")
+            }
+            
+        } label: {
+            Text("새 파일")
+        }
+    }
+    
+    private var editBtn: some View {
+        Button {
+            // TODO: 편집 기능
+        } label: {
+            Text("편집")
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/Blank/Blank/View/CurrentPageView.swift
+++ b/Blank/Blank/View/CurrentPageView.swift
@@ -1,0 +1,28 @@
+//
+//  CurrentPageView.swift
+//  Blank
+//
+//  Created by Greed on 10/18/23.
+//
+
+import SwiftUI
+
+struct CurrentPageView: View {
+    let image: UIImage?
+    
+    var body: some View {
+        if let image = image {
+            VStack {
+                Spacer().frame(height: 10)
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: UIScreen.main.bounds.height * 0.85)
+            }
+            .background(Color(.systemGray6))
+        } else {
+            Text("Error")
+        }
+    }
+}
+

--- a/Blank/Blank/View/Home/HomeView.swift
+++ b/Blank/Blank/View/Home/HomeView.swift
@@ -15,6 +15,7 @@ struct HomeView: View {
     @State var showImagePicker = false
     @State var showPDFCreateAlert = false
     @State var isClicked = false
+    @StateObject var overViewModel: OverViewModel
     
     // 새 PDF 생성 관련
     @State var newPDFFileName = ""
@@ -92,7 +93,7 @@ struct HomeView: View {
         return ScrollView {
             LazyVGrid(columns: columns) {
                 ForEach(viewModel.filteredFileList, id: \.id) { file in
-                    NavigationLink(destination: OverView()) {
+                    NavigationLink(destination: OverView(viewModel: overViewModel)) {
                         // TODO: 전체페이지와 시험본 페이지를 각 카드뷰에 넘겨주기
                         ZStack(alignment:.topTrailing) {
                             PDFThumbnailView(file: file)
@@ -168,7 +169,8 @@ extension HomeView {
     }
 }
 
-#Preview {
-    HomeView()
-        .environmentObject(HomeViewModel())
-}
+//#Preview {
+//    HomeView()
+//        .environmentObject(HomeViewModel())
+//}
+

--- a/Blank/Blank/View/OCREditView.swift
+++ b/Blank/Blank/View/OCREditView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct OCREditView: View {
     @Environment(\.dismiss) private var dismiss
+    @StateObject var viewModel: OverViewModel
     @State private var showingModal = true
     @Binding var isLinkActive: Bool
     
@@ -38,9 +39,11 @@ struct OCREditView: View {
     
     private var ocrEditImage: some View {
         // TODO: 텍스트필드를 사진 위에 올려서 확인할 텍스트와 함께 보여주기
-        Image("myImage")
-            .resizable()
-            .scaledToFit()
+        ScrollView {
+            CurrentPageView(image: viewModel.generateImage())
+        }
+        .frame(width: UIScreen.main.bounds.width)
+        .background(Color(.systemGray6))
     }
     
     private var backBtn: some View {
@@ -63,7 +66,7 @@ struct OCREditView: View {
     }
     
     private var nextBtn: some View {
-        NavigationLink(destination: TestPageView(isLinkActive: $isLinkActive)) {
+        NavigationLink(destination: TestPageView(viewModel: viewModel, isLinkActive: $isLinkActive)) {
             Text("시험보기")
                 .fontWeight(.bold)
         }
@@ -74,5 +77,5 @@ struct OCREditView: View {
 }
 
 #Preview {
-    OCREditView(isLinkActive: .constant(true))
+    OCREditView(viewModel: OverViewModel(),isLinkActive: .constant(true))
 }

--- a/Blank/Blank/View/OverViewModalView.swift
+++ b/Blank/Blank/View/OverViewModalView.swift
@@ -8,24 +8,78 @@
 import SwiftUI
 
 struct OverViewModalView: View {
-    let columns = Array(repeating: GridItem(.flexible(), spacing: 10), count: 4)
+    @StateObject var viewModel: OverViewModel
+    @Environment(\.dismiss) var dismiss
     
     var body: some View {
-        ScrollView {
-            LazyVGrid(columns: columns) {
-                ForEach(0..<10) {_ in
-                    NavigationLink(destination: OverView()) {
-                        // TODO: 기기에 따라 크기 조정 및 하단 정보들 넣기
-                        PDFThumbnailView(file: DUMMY_FILE)
-                    }
-                    .foregroundColor(.black)
-                }
+        let item = GridItem(.adaptive(minimum: 120, maximum: 130), spacing: 20)
+        let columns = Array(repeating: item, count: 4)
+        VStack {
+            HStack {
+                Spacer()
+                Button(action: {
+                    dismiss()
+                },label: {
+                    Text("Done")
+                        .padding(20)
+                })
             }
-            .padding()
+            Spacer().frame(height: 0)
+            Divider()
+            Spacer().frame(height: 0)
+            NavigationView {
+                ScrollView {
+                    ScrollViewReader { proxy in
+                        LazyVGrid(columns: columns) {
+                            ForEach(viewModel.thumbnails.indices, id: \.self) {index in
+                                // TODO: 기기에 따라 크기 조정
+                                VStack {
+                                    Image(uiImage: viewModel.thumbnails[index])
+                                        .resizable()
+                                        .scaledToFit()
+                                        .border(viewModel.currentPage == index + 1 ? Color.blue : Color.clear, width: 2)
+                                        .shadow(color: Color.black.opacity(0.3), radius: 5, x: 0, y: 0)
+                                        .onTapGesture {
+                                            DispatchQueue.main.async {
+                                                viewModel.currentPage = index + 1
+                                                dismiss()
+                                            }
+                                        }
+                                    HStack {
+                                        Text("\(index+1)")
+                                            .font(.caption)
+                                            .fontWeight(.bold)
+                                        Spacer()
+                                    }
+                                    Rectangle()
+                                        .frame(width: 80, height: 20)
+                                        .foregroundColor(Color(red: 0.46, green: 0.46, blue: 0.5).opacity(0.12))
+                                        .cornerRadius(40)
+                                        .overlay(
+                                            Text("n회차")
+                                                .tint(Color.blue)
+                                        )
+                                    Text("정답률 : 25%")
+                                    Text("문제 : 127개")
+                                    Text("정답 : 32개")
+                                }
+                                .foregroundColor(.black)
+                            }
+//                            .onChange(of: viewModel.currentPage) { value in
+//                                withAnimation {
+//                                    proxy.scrollTo(value-1, anchor: .top)
+//                                }
+//                            }
+                        }
+                    }
+                }
+                .padding()
+                .background(Color(.systemGray5))
+            }
         }
     }
 }
 
 #Preview {
-    OverViewModalView()
+    OverViewModalView(viewModel: OverViewModel())
 }

--- a/Blank/Blank/View/ResultPageView.swift
+++ b/Blank/Blank/View/ResultPageView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ResultPageView: View {
     @Environment(\.dismiss) private var dismiss
+    @StateObject var viewModel: OverViewModel
     @Binding var isLinkActive: Bool
     @State var seeCorrect: Bool = true
     
@@ -53,16 +54,17 @@ struct ResultPageView: View {
     }
     
     private var resultImage: some View {
-        VStack {
-            // TODO: 각 단어의 정답여부에 따른 색상 마스킹
-            Image("myImage")
-                .resizable()
-                .scaledToFit()
+        // TODO: 각 단어의 정답여부에 따른 색상 마스킹
+        ScrollView {
+            CurrentPageView(image: viewModel.generateImage())
         }
+        .frame(width: UIScreen.main.bounds.width)
+        .background(Color(.systemGray6))
     }
     
     private var homeBtn: some View {
-        NavigationLink(destination: HomeView()) {
+        // destination 임시처리
+        NavigationLink(destination: HomeView(overViewModel: OverViewModel())) {
             Image(systemName: "house")
         }
     }
@@ -90,5 +92,5 @@ struct ResultPageView: View {
 }
 
 #Preview {
-    ResultPageView(isLinkActive: .constant(true))
+    ResultPageView(viewModel: OverViewModel(), isLinkActive: .constant(true))
 }

--- a/Blank/Blank/View/TestPageView.swift
+++ b/Blank/Blank/View/TestPageView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct TestPageView: View {
     @Environment(\.dismiss) private var dismiss
+    @StateObject var viewModel: OverViewModel
     @State private var showingModal = false
     @Binding var isLinkActive: Bool
     
@@ -38,9 +39,11 @@ struct TestPageView: View {
     
     private var testImage: some View{
         // TODO: 시험볼 page에 textfield를 좌표에 만들어 보여주기
-        Image("myImage")
-            .resizable()
-            .scaledToFit()
+        ScrollView {
+            CurrentPageView(image: viewModel.generateImage())
+        }
+        .frame(width: UIScreen.main.bounds.width)
+        .background(Color(.systemGray6))
     }
     
     private var backBtn: some View {
@@ -63,7 +66,7 @@ struct TestPageView: View {
     }
     
     private var nextBtn: some View {
-        NavigationLink(destination: ResultPageView(isLinkActive: $isLinkActive)) {
+        NavigationLink(destination: ResultPageView(viewModel: viewModel, isLinkActive: $isLinkActive)) {
             Text("채점")
                 .fontWeight(.bold)
         }
@@ -74,5 +77,5 @@ struct TestPageView: View {
 }
 
 #Preview {
-    TestPageView(isLinkActive: .constant(true))
+    TestPageView(viewModel: OverViewModel(), isLinkActive: .constant(true))
 }

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct WordSelectView: View {
     @Environment(\.dismiss) private var dismiss
+    @StateObject var viewModel: OverViewModel
     @State private var showingAlert = true
     @Binding var isLinkActive: Bool
     
@@ -42,9 +43,11 @@ struct WordSelectView: View {
     
     private var wordSelectImage: some View {
         // TODO: 단어 선택시 해당 단어 위에 마스킹 생성 기능, 다시 터치시 해제
-        Image("myImage")
-            .resizable()
-            .scaledToFit()
+        ScrollView {
+            CurrentPageView(image: viewModel.generateImage())
+        }
+        .frame(width: UIScreen.main.bounds.width)
+        .background(Color(.systemGray6))
     }
     
     private var backBtn: some View {
@@ -56,7 +59,7 @@ struct WordSelectView: View {
     }
     
     private var nextBtn: some View {
-        NavigationLink(destination: OCREditView(isLinkActive: $isLinkActive)) {
+        NavigationLink(destination: OCREditView(viewModel: viewModel, isLinkActive: $isLinkActive)) {
             Text("다음")
                 .fontWeight(.bold)
         }
@@ -67,5 +70,5 @@ struct WordSelectView: View {
 }
 
 #Preview {
-    WordSelectView(isLinkActive: .constant(true))
+    WordSelectView(viewModel: OverViewModel(), isLinkActive: .constant(true))
 }

--- a/Blank/Blank/ViewModel/HomeViewModel.swift
+++ b/Blank/Blank/ViewModel/HomeViewModel.swift
@@ -79,6 +79,7 @@ class HomeViewModel: ObservableObject {
     /// 예제 파일들을 Document 폴더에 복사 (처음 설치했을 때만 실행되어야 함)
     static func copySampleFiles() {
         let sampleFiles: [URL] = [
+            Bundle.main.url(forResource: "samplepdf", withExtension: "pdf"),
             Bundle.main.url(forResource: "sample", withExtension: "pdf"),
             Bundle.main.url(forResource: "blank", withExtension: "pdf"),
             Bundle.main.url(forResource: "toeic", withExtension: "pdf"),

--- a/Blank/Blank/ViewModel/OverViewModel.swift
+++ b/Blank/Blank/ViewModel/OverViewModel.swift
@@ -1,0 +1,117 @@
+//
+//  PDFKitView.swift
+//  Blank
+//
+//  Created by Greed on 10/18/23.
+//
+
+import PDFKit
+import Foundation
+
+class OverViewModel: ObservableObject {
+    @Published var currentPage: Int = 1
+    @Published var thumbnails = [UIImage]()
+    @Published var isLoading = true
+    @Published var currentProgress: Double = 0.0
+    
+    let documentURL = Bundle.main.url(forResource: "samplepdf", withExtension: "pdf")
+    var pdfDocument: PDFDocument?
+    
+    init() {
+        if let documentURL = documentURL {
+            pdfDocument = PDFDocument(url: documentURL)
+        }
+    }
+    
+    // PDF 전체 페이지 수를 반환하는 메소드
+    func pdfTotalPage() -> Int {
+        guard let pdfDocument = pdfDocument else { return 0 }
+        
+        return pdfDocument.pageCount
+    }
+    
+    // PDF의 현재 페이지를 이미지로 반환하는 메소드
+    func generateImage() -> UIImage? {
+        guard let pdfDocument = pdfDocument, currentPage > 0, currentPage <= pdfDocument.pageCount else {
+            return nil
+        }
+        
+        guard let page = pdfDocument.page(at: currentPage - 1) else {
+            return nil
+        }
+        
+        let pageRect = page.bounds(for: .mediaBox)
+        let renderer = UIGraphicsImageRenderer(size: pageRect.size)
+        
+        let image = renderer.image { ctx in
+            UIColor.white.set()
+            ctx.fill(CGRect(origin: .zero, size: pageRect.size))
+            
+            ctx.cgContext.translateBy(x: 0, y: pageRect.size.height)
+            ctx.cgContext.scaleBy(x: 1, y: -1)
+            
+            page.draw(with: .mediaBox, to: ctx.cgContext)
+        }
+        return image
+    }
+    
+    // PDF의 모든 페이지를 썸네일 이미지로 배열에 저장하는 메소드
+//         func loadPDF() async {
+//            guard let pdfDocument = pdfDocument else {
+//                return
+//            }
+//
+//            thumbnails.removeAll() // 이미지 배열 초기화
+//
+//            DispatchQueue.global().async {
+//                for i in 0..<pdfDocument.pageCount {
+//                    guard let page = pdfDocument.page(at: i) else {
+//                        continue
+//                    }
+//
+//                    let image = page.thumbnail(of: CGSize(width: 500, height: 700), for: .mediaBox)
+//                    DispatchQueue.main.async {
+//                        self.thumbnails.append(image)
+//                    }
+//                }
+//            }
+//        }
+    
+    // PDF의 모든 페이지를 썸네일 이미지로 배열에 저장하는 메소드, 진행률도 표시
+    func loadThumbnails() {
+        isLoading = true
+        currentProgress = 0.0
+
+        guard let pdfDocument = pdfDocument else {
+            return
+        }
+
+        if thumbnails.count != pdfDocument.pageCount {
+            thumbnails.removeAll()
+            
+            Task.init { // Create a new Task for loading PDF
+                for i in 0..<pdfDocument.pageCount {
+                    guard let page = pdfDocument.page(at: i) else {
+                        continue
+                    }
+
+                    let image = page.thumbnail(of: CGSize(width: 100, height: 150), for: .mediaBox)
+                    
+                    await MainActor.run {
+                        self.thumbnails.append(image)
+                        self.currentProgress = Double(i + 1) / Double(pdfDocument.pageCount)
+                        
+                        if currentProgress == 1.0 {
+                            self.isLoading = false // Loading complete
+                        }
+                    }
+                }
+            }
+        } else {
+            isLoading = false // Loading complete
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
- PDFview 의 페이지를 이미지로 변환하는 기능
- 각 페이지 썸네일로 활용해서 모달뷰나 하단 스크롤뷰 기능 구현
- 각 페이지에 이미지를 pdf에서 변환한 이미지로 교체
- 
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
- 파일 로드시 로딩 뷰 구현
- PDF 페이지 이미지로 리턴 기능
- 오버뷰에 PDFView 구현해서 해당 페이지 이미지로 보여주기
- 하단 스크롤바 구현 및 페이지 선택 시 해당 페이지로 이동, 선택페이지는 스크롤바 가운데로 이동
- 스크롤바 및 모달 뷰에서 페이지 선택될 시 파란색으로 테두리 처리
- 모달 뷰 구현
- 다른 페이지들 pdf 페이지를 이미지로 바꾼 것으로 대체
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
