### PR TITLE
[Feat] #44 OCREditView까지 데이터 전달 

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		44A556742AE43774002AE4C3 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A556732AE43774002AE4C3 /* Int+.swift */; };
 		44A556762AE52990002AE4C3 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44A556752AE52990002AE4C3 /* String+.swift */; };
 		44F30BE22AE579E200B67014 /* APICRUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F30BE12AE579E200B67014 /* APICRUDView.swift */; };
+		44F30BE42AE6738000B67014 /* WordSelectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F30BE32AE6738000B67014 /* WordSelectViewModel.swift */; };
+		44F30BE62AE6781F00B67014 /* BasicWord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44F30BE52AE6781F00B67014 /* BasicWord.swift */; };
 		ACDBDA5D2AD7CC7600C44A80 /* BlankApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDBDA5C2AD7CC7600C44A80 /* BlankApp.swift */; };
 		ACDBDA612AD7CC7700C44A80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACDBDA602AD7CC7700C44A80 /* Assets.xcassets */; };
 		ACDBDA642AD7CC7700C44A80 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACDBDA632AD7CC7700C44A80 /* Preview Assets.xcassets */; };
@@ -89,6 +91,8 @@
 		44A556732AE43774002AE4C3 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		44A556752AE52990002AE4C3 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		44F30BE12AE579E200B67014 /* APICRUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICRUDView.swift; sourceTree = "<group>"; };
+		44F30BE32AE6738000B67014 /* WordSelectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordSelectViewModel.swift; sourceTree = "<group>"; };
+		44F30BE52AE6781F00B67014 /* BasicWord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicWord.swift; sourceTree = "<group>"; };
 		ACDBDA592AD7CC7600C44A80 /* Blank.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Blank.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ACDBDA5C2AD7CC7600C44A80 /* BlankApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankApp.swift; sourceTree = "<group>"; };
 		ACDBDA602AD7CC7700C44A80 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -243,6 +247,7 @@
 			children = (
 				4491DFA92ADD1E2E00CA5B42 /* HomeViewModel.swift */,
 				42E763892AE1229700624D81 /* OverViewModel.swift */,
+				44F30BE32AE6738000B67014 /* WordSelectViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -254,6 +259,7 @@
 				ACF338C12ADD0136004D20FC /* Page.swift */,
 				ACF338C32ADD0158004D20FC /* Session.swift */,
 				ACF338C52ADD0172004D20FC /* Word.swift */,
+				44F30BE52AE6781F00B67014 /* BasicWord.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -374,6 +380,7 @@
 				EBEB727F2AE548C400316D66 /* ScrribleModalView.swift in Sources */,
 				ACF338C42ADD0158004D20FC /* Session.swift in Sources */,
 				42ED60D82ADE7F910043AF2F /* PDFThumbnailView.swift in Sources */,
+				44F30BE62AE6781F00B67014 /* BasicWord.swift in Sources */,
 				449CB1EC2ADFAF560086758A /* PhotoPickerRepresentedView.swift in Sources */,
 				44A556762AE52990002AE4C3 /* String+.swift in Sources */,
 				4491DFEC2ADD4CF800CA5B42 /* Persistence.swift in Sources */,
@@ -388,6 +395,7 @@
 				449CB1E72ADEDC5E0086758A /* DummyObjects.swift in Sources */,
 				449CB1EA2ADEE0460086758A /* PDFUtil.swift in Sources */,
 				42ED60C62ADE7EDB0043AF2F /* HomeView.swift in Sources */,
+				44F30BE42AE6738000B67014 /* WordSelectViewModel.swift in Sources */,
 				4491DFEF2ADD4D4700CA5B42 /* Blank.xcdatamodeld in Sources */,
 				449CB1DA2ADED6C10086758A /* DocumentPickerRepresentedView.swift in Sources */,
 				42E7638A2AE1229700624D81 /* OverViewModel.swift in Sources */,

--- a/Blank/Blank/Model/BasicWord.swift
+++ b/Blank/Blank/Model/BasicWord.swift
@@ -1,0 +1,14 @@
+//
+//  BasicWord.swift
+//  Blank
+//
+//  Created by 윤범태 on 2023/10/23.
+//
+
+import Foundation
+
+struct BasicWord: Codable, Hashable, Identifiable {
+    var id: UUID
+    var wordValue: String
+    var rect: CGRect
+}

--- a/Blank/Blank/Model/Page.swift
+++ b/Blank/Blank/Model/Page.swift
@@ -16,5 +16,8 @@ struct Page: Codable, Hashable {
     var fileId: UUID
     var sessions: [Session] = []// 전체 회차 sessions  / 특정 n회차 세션 접근 page.sessions.session
     var currentPageNumber: Int
-    var basicWordCGRects: [CGRect] // [ (25,59,20,30) , (252,89,30,50) , ..... ]
+    var basicWords: [BasicWord] = [] // [ (25,59,20,30) , (252,89,30,50) , ..... ]
+    
+    // TODO: - 삭제해야됨
+    var basicWordCGRects: [CGRect]
 }

--- a/Blank/Blank/View/ImageView.swift
+++ b/Blank/Blank/View/ImageView.swift
@@ -1,3 +1,14 @@
+
+//
+//  ImageView.swift
+//  Blank
+//
+//  Created by 조용현 on 10/19/23.
+//
+
+
+
+
 import SwiftUI
 import Vision
 
@@ -7,10 +18,10 @@ struct ImageView: View {
     @Binding var visionStart:Bool
     @State private var recognizedBoxes: [(String, CGRect)] = []
     //경섭추가코드
-
-
-    @Binding var scale: CGFloat
-
+    @Binding var zoomScale: CGFloat
+    
+    @Binding var basicWords: [BasicWord]
+    
     var body: some View {
         GeometryReader { proxy in
             // ScrollView를 통해 PinchZoom시 좌우상하 이동
@@ -18,32 +29,36 @@ struct ImageView: View {
                 Image(uiImage: uiImage ?? UIImage())  //경섭추가코드를 받기위한 변경
                     .resizable()
                     .scaledToFit()
+                
                 // GeometryReader를 통해 화면크기에 맞게 이미지 사이즈 조정
-
-//                이미지가 없다면 , 현재 뷰의 너비(GeometryReader의 너비)를 사용하고
-//                더 작은 값을 반환할건데
-//                이미지 > GeometryReader 일 때 이미지는 GeometryReader의 크기에 맞게 축소.
-//                반대로 GeometryReader > 이미지면  이미지의 원래 크기를 사용
+                
+                //                이미지가 없다면 , 현재 뷰의 너비(GeometryReader의 너비)를 사용하고
+                //                더 작은 값을 반환할건데
+                //                이미지 > GeometryReader 일 때 이미지는 GeometryReader의 크기에 맞게 축소.
+                //                반대로 GeometryReader > 이미지면  이미지의 원래 크기를 사용
                     .frame(
-                        width: max(uiImage?.size.width ?? proxy.size.width, proxy.size.width) * scale,
-                        height: max(uiImage?.size.height ?? proxy.size.height, proxy.size.height) * scale
+                        
+                        width: max(uiImage?.size.width ?? proxy.size.width, proxy.size.width) * zoomScale,
+                        height: max(uiImage?.size.height ?? proxy.size.height, proxy.size.height) * zoomScale
                     )
                     .onChange(of: visionStart, perform: { newValue in
                         if let image = uiImage {
                             recognizeTextTwo(from: image) { recognizedTexts in
                                 self.recognizedBoxes = recognizedTexts
-                                for (text, rect) in recognizedTexts {
-                                    print("Text: \(text), Rect: \(rect)")
-                                }
+                                basicWords = recognizedTexts.map { .init(id: UUID(), wordValue: $0.0, rect: $0.1) }
+                                //                                for (text, rect) in recognizedTexts {
+                                //                                    print("Text: \(text), Rect: \(rect)")
+                                //                                }
                             }
                             
                             
                         }
                     })
-
+                
                 // 조조 코드 아래 일단 냅두고 위의 방식으로 수정했음
                     .overlay {
                         // TODO: Image 위에 올릴 컴포넌트(핀치줌 시 크기고정을 위해 width, height, x, y에 scale갑 곱하기)
+                        
                         ForEach(recognizedBoxes.indices, id: \.self) { index in
                             let box = recognizedBoxes[index]
                             Rectangle()
@@ -51,35 +66,51 @@ struct ImageView: View {
                                         adjustRect(box.1, in: proxy))
                                 .stroke(Color.red, lineWidth: 1)
                         }
-
-
+                        
+                        
                     }
+                
+                
             }
         }
     }
     
+    
+    
+    
+    // ---------- Mark : 반자동   ----------------
     func adjustRect(_ rect: CGRect, in geometry: GeometryProxy) -> CGRect {
+        
         let imageSize = self.uiImage?.size ?? CGSize(width: 1, height: 1)
         
-        // 2. & 3. SwiftUI의 Image 뷰와 실제 UIImage 사이의 스케일링 비율을 계산합니다.
-        let scaleX: CGFloat = geometry.size.width / imageSize.width  // Image 뷰 너비와 UIImage 너비 사이의 비율
-        let scaleY: CGFloat = geometry.size.height / imageSize.height // Image 뷰 높이와 UIImage 높이 사이의 비율
+        // Image 뷰 너비와 UIImage 너비 사이의 비율
+        let scaleY: CGFloat = geometry.size.height / imageSize.height
+//        let scaleX: CGFloat = geometry.size.width / imageSize.width
         
-        // 4. 두 스케일 중 작은 값을 선택하여 이미지의 가로 세로 비율을 유지합니다.
-        let scale: CGFloat = min(scaleX, scaleY) * self.scale  // 이 부분을 수정하여 이미지의 확대/축소 비율을 고려하도록 했습니다.
+//        print("----------------")
+//        print("imageSize.width: \(imageSize.width) , imageSize.height: \(imageSize.height)" )
+//        print("geometry.size.width: \(geometry.size.width) , geometry.size.height: \(geometry.size.width)")
+//        print("scaleX: \(scaleX) , scaleY: \(scaleY) , scale: \(zoomScale)")
+//        print("rect.origin.x: \(rect.origin.x) , rect.origin.y: \(rect.origin.y)")
+//        print("rect.size.width: \(rect.size.width) , rect.size.height: \(rect.size.height)")
+//        print("----------------")
         
-        let offsetXAdjustment: CGFloat = 0.0
-        let offsetX: CGFloat = ((geometry.size.width - imageSize.width * scale) / 2.0) + offsetXAdjustment
-        let offsetY = (geometry.size.height - imageSize.height * scale) / 2
-
+        
         return CGRect(
-            x: rect.origin.x * scale + offsetX,
-            y: (imageSize.height - rect.origin.y - rect.size.height) * scale + offsetY,
-            width: rect.width * scale,
-            height: rect.height * scale
+            
+            
+            x: ( ( (geometry.size.width - imageSize.width) / 3.5 )  + (rect.origin.x * scaleY))   *  zoomScale   ,
+            
+            // 좌우반전
+            //                x:  (imageSize.width - rect.origin.x - rect.size.width) * scaleX * scale ,
+            
+            y:( imageSize.height - rect.origin.y - rect.size.height) * scaleY * zoomScale ,
+            width: rect.width * scaleY * zoomScale,
+            height : rect.height * scaleY * zoomScale
         )
     }
-
+    
+    
     
     
     
@@ -91,16 +122,16 @@ struct ImageView: View {
         guard let cgImage = image.cgImage else { return }
         // VNImageRequestHandler옵션에 URL로 경로 할 수도 있고 화면회전에 대한 옵션도 가능
         let requestHandler = VNImageRequestHandler(cgImage: cgImage)
-
+        
         // 텍스트 인식 작업이 완료되었을때 실행할 클로저 정의
         let request = VNRecognizeTextRequest { (request, error) in
             var recognizedTexts: [(String, CGRect)] = [] // 단어랑 좌표값담을 빈 배열 튜플 생성
-
+            
             if let results = request.results as? [VNRecognizedTextObservation] {
                 for observation in results {
                     if let topCandidate = observation.topCandidates(1).first {
                         let words = topCandidate.string.split(separator: " ")
-
+                        
                         for word in words {
                             if let range = topCandidate.string.range(of: String(word)) {
                                 if let box = try? topCandidate.boundingBox(for: range) {
@@ -114,18 +145,18 @@ struct ImageView: View {
             }
             completion(recognizedTexts)
         }
-
+        
         request.recognitionLanguages = ["ko-KR"]
         request.recognitionLevel = .accurate
-
+        
         do {
             try requestHandler.perform([request])
         } catch {
             print("Error performing text recognition request: \(error)")
         }
     }
-    
 }
+
 //
 //#Preview {
 //    ImageView(scale: .constant(1.0))

--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -15,11 +15,20 @@ struct OCREditView: View {
     @State var visionStart: Bool = false
     @State var type = ScrribleType.write
     @State private var hasTypeValueChanged = false
+    
+    /*
+     전단계 WordSelectView에서 단어를 선택하면
+     해당 단어 목록은 현재 Session 內 Words에 들어가야 할 것 같음
+     */
+    
+    // TODO: - 현재(또는 새로운) 세션 세팅하기
+    @State var page: Page
 
     var body: some View {
         NavigationStack {
             VStack {
                 ocrEditImage
+                
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
@@ -39,6 +48,9 @@ struct OCREditView: View {
             .navigationBarBackButtonHidden()
         }
         .background(Color(.systemGray6))
+        .onAppear {
+            print("OCREditView's basicWords.", page)
+        }
     }
     
     private var ocrEditImage: some View {

--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -43,7 +43,7 @@ struct OCREditView: View {
     
     private var ocrEditImage: some View {
         // TODO: 텍스트필드를 사진 위에 올려서 확인할 텍스트와 함께 보여주기
-        PinchZoomView(image: generatedImage, visionStart: $visionStart)
+        PinchZoomView(image: generatedImage, visionStart: $visionStart, basicWords: .constant([]))
     }
     
     private var backBtn: some View {

--- a/Blank/Blank/View/OverView.swift
+++ b/Blank/Blank/View/OverView.swift
@@ -13,7 +13,7 @@ struct OverView: View {
     @Environment(\.dismiss) private var dismiss
     
     //뷰모델
-    @ObservedObject var overViewModel: OverViewModel
+    @StateObject var overViewModel: OverViewModel
     
     //향후 오버뷰 페이지로 돌아오기 위한 flag
     @State var isLinkActive = false
@@ -41,6 +41,7 @@ struct OverView: View {
 
                 } else if !overViewModel.thumbnails.isEmpty {
                     //경섭추가코드
+                    
                     PinchZoomView(image: overViewModel.generateImage(), visionStart: $visionStart, basicWords: $overViewModel.basicWords)
                     //경섭추가코드
                     bottomScrollView
@@ -81,7 +82,14 @@ struct OverView: View {
 
         .navigationDestination(isPresented: $isLinkActive) {
             if !goToTestPage {
-                WordSelectView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, basicWords: overViewModel.basicWords)
+                // TODO: - 이미 생성한 페이지라면 다시 생성되지 않게 해야됨, CoreData에서 페이지 있는지 검사
+                let page = Page(id: UUID(), 
+                                fileId: overViewModel.currentFile.id,
+                                currentPageNumber: overViewModel.currentPage,
+                                basicWords: overViewModel.basicWords,
+                                basicWordCGRects: []
+                )
+                WordSelectView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, page: page)
             } else {
                 TestPageView(isLinkActive: $isLinkActive, generatedImage: $generatedImage)
             }

--- a/Blank/Blank/View/OverView.swift
+++ b/Blank/Blank/View/OverView.swift
@@ -5,7 +5,9 @@
 //  Created by Greed on 10/14/23.
 //
 
+
 import SwiftUI
+import Vision
 
 struct OverView: View {
     @Environment(\.dismiss) private var dismiss
@@ -30,17 +32,25 @@ struct OverView: View {
     @State private var generatedImage: UIImage?
     @State private var currentPageText: String = ""
     @State var titleName = "파일이름"
-    
+
     var body: some View {
         NavigationStack {
             VStack {
                 if overViewModel.isLoading && overViewModel.currentProgress < 1.0 {
                     progressStatus
+
                 } else if !overViewModel.thumbnails.isEmpty {
-                    currentPageImage
+                    //경섭추가코드
+                    PinchZoomView(image: overViewModel.generateImage(), visionStart: $visionStart, basicWords: $overViewModel.basicWords)
+                    //경섭추가코드
                     bottomScrollView
+                    
+                    // 하단 빈공간 코드
+//                    Spacer().frame(height : UIScreen.main.bounds.height * 0.12)
+                    
                 }
             }
+            .background(Color(.systemGray4))
             .onAppear {
                 overViewModel.loadThumbnails()
                 generatedImage = overViewModel.generateImage()
@@ -52,11 +62,11 @@ struct OverView: View {
                 ToolbarItem(placement: .topBarLeading) {
                     leftBtns
                 }
-                
+
                 ToolbarItem(placement: .topBarTrailing) {
                     testBtn
                 }
-                
+
                 ToolbarItem(placement: .principal) {
                     centerBtn
                 }
@@ -66,33 +76,33 @@ struct OverView: View {
             .navigationBarBackButtonHidden()
             .navigationTitle(titleName)
             .navigationBarTitleDisplayMode(.inline)
+            
         }
-        .background(Color(.systemGray6))
+
         .navigationDestination(isPresented: $isLinkActive) {
             if !goToTestPage {
-                WordSelectView(isLinkActive: $isLinkActive, generatedImage: $generatedImage)
+                WordSelectView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, basicWords: overViewModel.basicWords)
             } else {
                 TestPageView(isLinkActive: $isLinkActive, generatedImage: $generatedImage)
             }
         }
+
     }
-    
+
     private var progressStatus: some View {
         VStack(spacing: 20) {
             ProgressView(value: overViewModel.currentProgress)
                 .progressViewStyle(CircularProgressViewStyle(tint: .blue))
-            
+
             Text("파일을 로딩 중 입니다.")
-            
+
             Text("\(Int(overViewModel.currentProgress * 100))%") // 퍼센트로 변환하여 표시
         }
         .background(.white)
     }
-    
-    private var currentPageImage: some View {
-        PinchZoomView(image: generatedImage, visionStart: $visionStart)
-    }
-    
+
+
+
     private var bottomScrollView: some View {
         ScrollView(.horizontal, showsIndicators: true) {
             Spacer().frame(height: 10)
@@ -130,6 +140,9 @@ struct OverView: View {
         .frame(height : UIScreen.main.bounds.height * 0.11)
     }
     
+    
+    
+
     private var centerBtn: some View {
         Button {
             showPopover = true
@@ -145,7 +158,7 @@ struct OverView: View {
             popoverContent
         }
     }
-    
+
     private var popoverContent: some View {
         VStack {
             Form {
@@ -170,7 +183,7 @@ struct OverView: View {
             currentPageText = "\(overViewModel.currentPage)"
         }
     }
-    
+
     private var leftBtns: some View {
         HStack {
             Button {
@@ -178,7 +191,7 @@ struct OverView: View {
             } label: {
                 Image(systemName: "chevron.left")
             }
-            
+
             Button {
                 showModal = true
             } label: {
@@ -187,7 +200,7 @@ struct OverView: View {
             .sheet(isPresented: $showModal) {
                 OverViewModalView(overViewModel: overViewModel)
             }
-            
+
             Menu {
                 // TODO: 회차가 끝날때마다 해당 회차 결과 생성 및 시험 본 부분 색상 처리(버튼으로)
                 Text("전체통계")
@@ -195,12 +208,12 @@ struct OverView: View {
                 Text("2회차")
                 Text("3회차")
                 Text("4회차")
-                
+
             } label: {
                 Label("결과보기", systemImage: "chevron.down")
                     .labelStyle(.titleAndIcon)
             }
-            
+
             Button {
                 // TODO: 원본 페이지 상태로 변경
             } label: {
@@ -208,39 +221,56 @@ struct OverView: View {
             }
         }
     }
-    
+
     private var testBtn: some View {
-        Button {
-            // TODO: 해당 페이지 이미지 파일로 넘겨주기, layer 분리, 이미지 받아서 텍스트로 변환, 2회차 이상일때 내용수정 Alert 만들기
-            isLinkActive = true
-            // TODO: 2회차 이상일때 alert 띄울 로직
-            //            showingAlert = true
-        } label: {
-            Text("시험준비")
-                .fontWeight(.bold)
-        }
-        .alert("내용수정" ,isPresented: $showingAlert) {
-            Button("시험보기") {
-                goToTestPage = true
-            }
-            Button("수정하기") {
-                
-            }
-            Button("취소", role: .cancel) {
-                
-            }
-        } message: {
-            Text("""
-                 기존에 시험을 본 내용이 있습니다.
-                 바로 시험을 보시겠습니까?
-                 수정하시겠습니까?
-                 """)
-        }
         
+        Button("시험준비") {
+            visionStart = true
+            isLinkActive = true
+        }
+
+//        Button {
+//            // TODO: 해당 페이지 이미지 파일로 넘겨주기, layer 분리, 이미지 받아서 텍스트로 변환, 2회차 이상일때 내용수정 Alert 만들기
+//            isLinkActive = true
+//            // TODO: 2회차 이상일때 alert 띄울 로직
+//            //            showingAlert = true
+//        } label: {
+//            Text("시험준비")
+//                .fontWeight(.bold)
+//        }
+//        .alert("내용수정" ,isPresented: $showingAlert) {
+//            Button("시험보기") {
+//                goToTestPage = true
+//            }
+//            Button("수정하기") {
+//
+//            }
+//            Button("취소", role: .cancel) {
+//
+//
+//            }
+//        } message: {
+//            Text("""
+//                 기존에 시험을 본 내용이 있습니다.
+//                 바로 시험을 보시겠습니까?
+//                 수정하시겠습니까?
+//                 """)
+//        }
     }
     
 }
 
+        
+
+    
+
+
+
+    
+
+
+
 //#Preview {
-//    OverView(viewModel: OverViewModel(currentFile: File))
+//    OverView(overViewModel: OverViewModel())
 //}
+

--- a/Blank/Blank/View/Persistence/APICRUDView.swift
+++ b/Blank/Blank/View/Persistence/APICRUDView.swift
@@ -23,7 +23,7 @@ struct APICRUDView: View {
                 }
                 
                 ForEach(pages ?? [], id: \.id) { page in
-                    Text("Page: \(page.id), \(page.basicWordCGRects.first?.stringValue ?? "")")
+                    Text("Page: \(page.id), \(page.basicWords.first?.rect.stringValue ?? "")")
                 }
                 
                 ForEach(sessions ?? [], id: \.id) { session in

--- a/Blank/Blank/View/PinchZoomView.swift
+++ b/Blank/Blank/View/PinchZoomView.swift
@@ -1,4 +1,18 @@
+
+
+//
+//  PinchZoomView.swift
+//  Blank
+//
+//  Created by 조용현 on 10/19/23.
+//
+
+
+
 import SwiftUI
+
+
+
 
 
 struct PinchZoomView: View {
@@ -6,6 +20,7 @@ struct PinchZoomView: View {
     // Image 정보를 받을 수 있도록 프로퍼티 추가 - 경섭
     var image: UIImage?
     @Binding var visionStart:Bool
+    @Binding var basicWords: [BasicWord]
     
     //
     @State private var scale: CGFloat = 1.0
@@ -31,7 +46,7 @@ struct PinchZoomView: View {
 
     var body: some View {
         // ImageView를 불러와서 Gesture 적용
-        ImageView(uiImage: image, visionStart: $visionStart ,scale: $scale)
+        ImageView(uiImage: image, visionStart: $visionStart, zoomScale: $scale, basicWords: $basicWords)
             .gesture(magnification)
     }
     // 변경값을 lastScale에 저장하여 다음 확대시 lastScale에서부터 시작

--- a/Blank/Blank/View/ResultPageView.swift
+++ b/Blank/Blank/View/ResultPageView.swift
@@ -57,7 +57,7 @@ struct ResultPageView: View {
     
     private var resultImage: some View {
         // TODO: 각 단어의 정답여부에 따른 색상 마스킹
-        PinchZoomView(image: generatedImage, visionStart: $visionStart)
+        PinchZoomView(image: generatedImage, visionStart: $visionStart, basicWords: .constant([]))
     }
     
     private var homeBtn: some View {

--- a/Blank/Blank/View/TestPageView.swift
+++ b/Blank/Blank/View/TestPageView.swift
@@ -43,7 +43,7 @@ struct TestPageView: View {
     
     private var testImage: some View{
         // TODO: 시험볼 page에 textfield를 좌표에 만들어 보여주기
-        PinchZoomView(image: generatedImage, visionStart: $visionStart)
+        PinchZoomView(image: generatedImage, visionStart: $visionStart, basicWords: .constant([]))
     }
     
     private var backBtn: some View {

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -45,7 +45,7 @@ struct WordSelectView: View {
         }
         .background(Color(.systemGray6))
         .onAppear {
-            debugPrint("WordSelectView's basicWords.", page)
+            // print("WordSelectView's basicWords.", page)
         }
 
     }
@@ -70,7 +70,7 @@ struct WordSelectView: View {
     }
     
     private var nextBtn: some View {
-        NavigationLink(destination: OCREditView(isLinkActive: $isLinkActive, generatedImage: $generatedImage)) {
+        NavigationLink(destination: OCREditView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, page: page)) {
             Text("다음")
                 .fontWeight(.bold)
         }

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -14,7 +14,8 @@ struct WordSelectView: View {
     @State var visionStart: Bool = false
     @Binding var generatedImage: UIImage?
     
-    @State var basicWords: [BasicWord] = []
+    // @State var basicWords: [BasicWord] = []
+    @State var page: Page
     
     var body: some View {
         NavigationStack {
@@ -44,7 +45,7 @@ struct WordSelectView: View {
         }
         .background(Color(.systemGray6))
         .onAppear {
-            print("WordSelectView's basicWords.", basicWords.first as Any)
+            debugPrint("WordSelectView's basicWords.", page)
         }
 
     }
@@ -55,7 +56,7 @@ struct WordSelectView: View {
             // ForEach(basicWords, id: \.id) { basicWord in
             //     Text("\(basicWord.wordValue), \(basicWord.rect.debugDescription)")
             // }
-            PinchZoomView(image: generatedImage, visionStart: $visionStart, basicWords: $basicWords)
+            PinchZoomView(image: generatedImage, visionStart: $visionStart, basicWords: $page.basicWords)
         }
         
     }

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -14,6 +14,8 @@ struct WordSelectView: View {
     @State var visionStart: Bool = false
     @Binding var generatedImage: UIImage?
     
+    @State var basicWords: [BasicWord] = []
+    
     var body: some View {
         NavigationStack {
             VStack {
@@ -41,11 +43,21 @@ struct WordSelectView: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .background(Color(.systemGray6))
+        .onAppear {
+            print("WordSelectView's basicWords.", basicWords.first as Any)
+        }
+
     }
     
     private var wordSelectImage: some View {
         // TODO: 단어 선택시 해당 단어 위에 마스킹 생성 기능, 다시 터치시 해제, 비전 스타트가 여기에 필요한지..?
-        PinchZoomView(image: generatedImage, visionStart: $visionStart)
+        VStack {
+            // ForEach(basicWords, id: \.id) { basicWord in
+            //     Text("\(basicWord.wordValue), \(basicWord.rect.debugDescription)")
+            // }
+            PinchZoomView(image: generatedImage, visionStart: $visionStart, basicWords: $basicWords)
+        }
+        
     }
     
     private var backBtn: some View {

--- a/Blank/Blank/ViewModel/OverViewModel.swift
+++ b/Blank/Blank/ViewModel/OverViewModel.swift
@@ -16,8 +16,12 @@ class OverViewModel: ObservableObject {
     @Published var isLoading = true
     @Published var currentProgress: Double = 0.0
     
+    /// OverView 내에 있는 PinchZoom-ImageView에서 받은 빨간 박스(Basic Words)들을 저장합니다.
+    @Published var basicWords: [BasicWord] = []
+    
     let currentFile: File
     lazy var pdfDocument: PDFDocument = PDFDocument(url: currentFile.fileURL)!
+
     
     init(currentFile: File) {
         self.currentFile = currentFile
@@ -63,6 +67,8 @@ class OverViewModel: ObservableObject {
             
             page.draw(with: .mediaBox, to: ctx.cgContext)
         }
+        
+        
         return image
     }
     

--- a/Blank/Blank/ViewModel/WordSelectViewModel.swift
+++ b/Blank/Blank/ViewModel/WordSelectViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  WordSelectViewModel.swift
+//  Blank
+//
+//  Created by 윤범태 on 2023/10/23.
+//
+
+import Foundation
+
+class WordSelectViewModel: ObservableObject {
+    @Published var basicWordRects: [BasicWord] = []
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- 데이터 전달

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 선택 기능이 구현되지 않아 `Page`의 `BasicWords`를 그대로 넘기도록 하였습니다.
- 튜플 및 CGRect와 SwiftUI가 `Identifiable`을 준수하지 않기 때문에 'BasicWord'라는 새로운 데이터 모델을 생성하였습니다.

## 주요 로직(Optional)
```swift
struct BasicWord: Codable, Hashable, Identifiable {
    var id: UUID
    var wordValue: String
    var rect: CGRect
}```