### PR TITLE
48 design testpageview image 및 pinchzoom 적용

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		ACF338C42ADD0158004D20FC /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C32ADD0158004D20FC /* Session.swift */; };
 		ACF338C62ADD0172004D20FC /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C52ADD0172004D20FC /* Word.swift */; };
 		EB69FC7A2AE6B5AE00ADF7B6 /* OCRPinchZoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB69FC792AE6B5AE00ADF7B6 /* OCRPinchZoomView.swift */; };
+		EB69FC7D2AE6C71F00ADF7B6 /* TestPageImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB69FC7C2AE6C71F00ADF7B6 /* TestPageImageView.swift */; };
+		EB69FC7F2AE6C77C00ADF7B6 /* TestPagePinchZoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB69FC7E2AE6C77C00ADF7B6 /* TestPagePinchZoomView.swift */; };
 		EB8978ED2AE5644400494BE7 /* handWrite.mov in Resources */ = {isa = PBXBuildFile; fileRef = EB8978E82AE5644400494BE7 /* handWrite.mov */; };
 		EB8978EE2AE5644400494BE7 /* insert.mov in Resources */ = {isa = PBXBuildFile; fileRef = EB8978E92AE5644400494BE7 /* insert.mov */; };
 		EB8978EF2AE5644400494BE7 /* delete.mov in Resources */ = {isa = PBXBuildFile; fileRef = EB8978EA2AE5644400494BE7 /* delete.mov */; };
@@ -105,6 +107,8 @@
 		ACF338C32ADD0158004D20FC /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		ACF338C52ADD0172004D20FC /* Word.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Word.swift; sourceTree = "<group>"; };
 		EB69FC792AE6B5AE00ADF7B6 /* OCRPinchZoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRPinchZoomView.swift; sourceTree = "<group>"; };
+		EB69FC7C2AE6C71F00ADF7B6 /* TestPageImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPageImageView.swift; sourceTree = "<group>"; };
+		EB69FC7E2AE6C77C00ADF7B6 /* TestPagePinchZoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestPagePinchZoomView.swift; sourceTree = "<group>"; };
 		EB8978E82AE5644400494BE7 /* handWrite.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = handWrite.mov; sourceTree = "<group>"; };
 		EB8978E92AE5644400494BE7 /* insert.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = insert.mov; sourceTree = "<group>"; };
 		EB8978EA2AE5644400494BE7 /* delete.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = delete.mov; sourceTree = "<group>"; };
@@ -282,11 +286,21 @@
 				42ED60C92ADE7F090043AF2F /* OverViewModalView.swift */,
 				42ED60CB2ADE7F1A0043AF2F /* WordSelectView.swift */,
 				EBEB727D2AE548AB00316D66 /* OCREdit */,
-				42ED60D12ADE7F450043AF2F /* TestPageView.swift */,
+				EB69FC7B2AE6BF2200ADF7B6 /* TestPage */,
 				42ED60D32ADE7F570043AF2F /* ResultPageView.swift */,
 				42ED60D52ADE7F6C0043AF2F /* CorrectInfoView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		EB69FC7B2AE6BF2200ADF7B6 /* TestPage */ = {
+			isa = PBXGroup;
+			children = (
+				42ED60D12ADE7F450043AF2F /* TestPageView.swift */,
+				EB69FC7C2AE6C71F00ADF7B6 /* TestPageImageView.swift */,
+				EB69FC7E2AE6C77C00ADF7B6 /* TestPagePinchZoomView.swift */,
+			);
+			path = TestPage;
 			sourceTree = "<group>";
 		};
 		EBEB727D2AE548AB00316D66 /* OCREdit */ = {
@@ -398,6 +412,7 @@
 				ACF338C02ADD00DC004D20FC /* File.swift in Sources */,
 				4491DFAA2ADD1E2E00CA5B42 /* HomeViewModel.swift in Sources */,
 				42ED60C82ADE7EF50043AF2F /* OverView.swift in Sources */,
+				EB69FC7F2AE6C77C00ADF7B6 /* TestPagePinchZoomView.swift in Sources */,
 				ACF338C22ADD0136004D20FC /* Page.swift in Sources */,
 				44F30BE22AE579E200B67014 /* APICRUDView.swift in Sources */,
 				EB8978FB2AE6A0BC00494BE7 /* TextView.swift in Sources */,
@@ -417,6 +432,7 @@
 				ACDBDA5D2AD7CC7600C44A80 /* BlankApp.swift in Sources */,
 				449CB1F02AE14A290086758A /* CGRect+.swift in Sources */,
 				4491DFF32ADD4EEB00CA5B42 /* PersistenceView.swift in Sources */,
+				EB69FC7D2AE6C71F00ADF7B6 /* TestPageImageView.swift in Sources */,
 				44A556742AE43774002AE4C3 /* Int+.swift in Sources */,
 				4491DFF92ADECF7F00CA5B42 /* UIImage+.swift in Sources */,
 				EBEB72622AE0BC8500316D66 /* ImageView.swift in Sources */,

--- a/Blank/Blank/View/OCREdit/TextView.swift
+++ b/Blank/Blank/View/OCREdit/TextView.swift
@@ -16,7 +16,7 @@ struct TextView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            UITextViewRepresentable(text: $name, isFocused: $isFocused, height: $height)
+            UITextViewRepresentable(text: $name, isFocused: $isFocused, height: $height, scale: $scale)
                 .frame(width: width, height: height)
         }
         .border(isFocused ? Color.yellow : Color.green, width: 1.5)
@@ -28,12 +28,13 @@ struct UITextViewRepresentable: UIViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
     @Binding var height: CGFloat
-    var scale: CGFloat = 1.5
+    @Binding var scale: CGFloat
+    var fontSize: CGFloat = 1.5
 
     func makeUIView(context: UIViewRepresentableContext<UITextViewRepresentable>) -> UITextView {
         let textView = UITextView(frame: .zero)
         textView.delegate = context.coordinator
-        textView.font = UIFont(name: "Avenir", size: (height/scale))
+        textView.font = UIFont(name: "Avenir", size: (height/fontSize) * scale)
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textView.textContainer.maximumNumberOfLines = 2
         return textView

--- a/Blank/Blank/View/TestPage/TestPageImageView.swift
+++ b/Blank/Blank/View/TestPage/TestPageImageView.swift
@@ -1,13 +1,13 @@
 //
-//  OCRImageView.swift
+//  TestPageImageView.swift
 //  Blank
 //
-//  Created by 조용현 on 10/23/23.
+//  Created by 조용현 on 10/24/23.
 //
 
 import SwiftUI
 
-struct OCRImageView: View {
+struct TestPageImageView: View {
 
     var uiImage: UIImage?
     @State private var recognizedBoxes: [(String, CGRect)] = []
@@ -36,7 +36,7 @@ struct OCRImageView: View {
                             @State var originX = box.origin.x
                             @State var originY = box.origin.y
 
-                            TextView(name: rect.0, height: $height, width: $width, scale: $zoomScale)
+                            TextView(height: $height, width: $width, scale: $zoomScale)
                                 .position(CGPoint(x: (originX + (width/2)), y: (originY + (height/2))))
                         }
                     }
@@ -62,6 +62,6 @@ struct OCRImageView: View {
     }
 }
 
-#Preview {
-    HomeView().environmentObject(HomeViewModel())
-}
+//#Preview {
+//    TestPageImageView()
+//}

--- a/Blank/Blank/View/TestPage/TestPagePinchZoomView.swift
+++ b/Blank/Blank/View/TestPage/TestPagePinchZoomView.swift
@@ -1,0 +1,65 @@
+//
+//  TestPagePinchZoomView.swift
+//  Blank
+//
+//  Created by 조용현 on 10/24/23.
+//
+
+import SwiftUI
+
+struct TestPagePinchZoomView: View {
+
+    // Image 정보를 받을 수 있도록 프로퍼티 추가 - 경섭
+    var image: UIImage?
+    @Binding var basicWords: [BasicWord]
+
+    //
+    @State private var scale: CGFloat = 1.0
+    @State var lastScale: CGFloat = 1.0
+    private let minScale = 1.0
+    private let maxScale = 5.0
+
+    var magnification: some Gesture {
+        // PinchZoom Gesture
+        MagnificationGesture()
+        // 확대 시작 시
+            .onChanged { state in
+                adjustScale(from: state)
+            }
+        // 확대 종료 시
+            .onEnded { state in
+                withAnimation {
+                    validateScaleLimits()
+                }
+                lastScale = 1.0
+            }
+    }
+
+    var body: some View {
+        // ImageView를 불러와서 Gesture 적용
+        TestPageImageView(uiImage: image, zoomScale: $scale, basicWords: $basicWords)
+            .gesture(magnification)
+    }
+    // 변경값을 lastScale에 저장하여 다음 확대시 lastScale에서부터 시작
+    func adjustScale(from state: MagnificationGesture.Value) {
+        let delta = state / lastScale
+        scale *= delta
+        lastScale = state
+    }
+    func getMinimumScaleAllowed() -> CGFloat {
+        return max(scale, minScale)
+    }
+    func getMaximumScaleAllowed() -> CGFloat {
+        return min(scale, maxScale)
+    }
+    // 확대 Scale min(1.0), max(3.0) 설정
+    func validateScaleLimits() {
+        scale = getMinimumScaleAllowed()
+        scale = getMaximumScaleAllowed()
+    }
+}
+
+
+//#Preview {
+//    TestPagePinchZoomView()
+//}

--- a/Blank/Blank/View/TestPage/TestPageView.swift
+++ b/Blank/Blank/View/TestPage/TestPageView.swift
@@ -44,7 +44,7 @@ struct TestPageView: View {
     
     private var testImage: some View{
         // TODO: 시험볼 page에 textfield를 좌표에 만들어 보여주기
-        PinchZoomView(image: generatedImage, visionStart: $visionStart, basicWords: .constant([]))
+        TestPagePinchZoomView(image: generatedImage, basicWords: .constant([]))
     }
     
     private var backBtn: some View {


### PR DESCRIPTION
## 개요 및 관련 이슈
testpageview image 및 pinchzoom 적용
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
testpageview image 및 pinchzoom 적용
font 사이즈 고정
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
