### PR TITLE
[feat] viewModal page구조체로 변경

### DIFF
--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -56,7 +56,7 @@ struct OCREditView: View {
     
     private var ocrEditImage: some View {
         // TODO: 텍스트필드를 사진 위에 올려서 확인할 텍스트와 함께 보여주기
-        OCRPinchZoomView(image: generatedImage, basicWords: .constant([]))
+        OCRPinchZoomView(image: generatedImage, page: $page)
     }
     
     private var backBtn: some View {
@@ -79,7 +79,7 @@ struct OCREditView: View {
     }
     
     private var nextBtn: some View {
-        NavigationLink(destination: TestPageView(isLinkActive: $isLinkActive, generatedImage: $generatedImage)) {
+        NavigationLink(destination: TestPageView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, page: page)) {
             Text("시험보기")
                 .fontWeight(.bold)
         }

--- a/Blank/Blank/View/OCREdit/OCRImageView.swift
+++ b/Blank/Blank/View/OCREdit/OCRImageView.swift
@@ -13,7 +13,7 @@ struct OCRImageView: View {
     @State private var recognizedBoxes: [(String, CGRect)] = []
     //경섭추가코드
     @Binding var zoomScale: CGFloat
-    @Binding var basicWords: [BasicWord]
+    @Binding var page: Page
 
     var body: some View {
         GeometryReader { proxy in
@@ -28,15 +28,14 @@ struct OCRImageView: View {
                         height: max(uiImage?.size.height ?? proxy.size.height, proxy.size.height) * zoomScale
                     )
                     .overlay {
-                        ForEach(recognizedBoxes.indices, id: \.self) { index in
-                            let rect = recognizedBoxes[index]
-                            let box = adjustRect(rect.1, in: proxy)
+                        ForEach(page.sessions[0].words, id: \.self) { word in
+                            let box = adjustRect(word.rect, in: proxy)
                             @State var width = box.width
                             @State var height = box.height
                             @State var originX = box.origin.x
                             @State var originY = box.origin.y
 
-                            TextView(name: rect.0, height: $height, width: $width, scale: $zoomScale)
+                            TextView(name: word.wordValue, height: $height, width: $width, scale: $zoomScale)
                                 .position(CGPoint(x: (originX + (width/2)), y: (originY + (height/2))))
                         }
                     }

--- a/Blank/Blank/View/OCREdit/OCRPinchZoomView.swift
+++ b/Blank/Blank/View/OCREdit/OCRPinchZoomView.swift
@@ -11,7 +11,7 @@ struct OCRPinchZoomView: View {
 
     // Image 정보를 받을 수 있도록 프로퍼티 추가 - 경섭
     var image: UIImage?
-    @Binding var basicWords: [BasicWord]
+    @Binding var page: Page
 
     //
     @State private var scale: CGFloat = 1.0
@@ -37,7 +37,7 @@ struct OCRPinchZoomView: View {
 
     var body: some View {
         // ImageView를 불러와서 Gesture 적용
-        OCRImageView(uiImage: image, zoomScale: $scale, basicWords: $basicWords)
+        OCRImageView(uiImage: image, zoomScale: $scale, page: $page)
             .gesture(magnification)
     }
     // 변경값을 lastScale에 저장하여 다음 확대시 lastScale에서부터 시작

--- a/Blank/Blank/View/OverView.swift
+++ b/Blank/Blank/View/OverView.swift
@@ -94,7 +94,14 @@ struct OverView: View {
                 )
                 WordSelectView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, page: page)
             } else {
-                TestPageView(isLinkActive: $isLinkActive, generatedImage: $generatedImage)
+// 나중에 조건 수정
+                let page = Page(id: UUID(),
+                                fileId: overViewModel.currentFile.id,
+                                currentPageNumber: overViewModel.currentPage,
+                                basicWords: overViewModel.basicWords,
+                                basicWordCGRects: []
+)
+                TestPageView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, page: page)
             }
         }
 

--- a/Blank/Blank/View/TestPage/TestPageImageView.swift
+++ b/Blank/Blank/View/TestPage/TestPageImageView.swift
@@ -13,8 +13,8 @@ struct TestPageImageView: View {
     @State private var recognizedBoxes: [(String, CGRect)] = []
     //경섭추가코드
     @Binding var zoomScale: CGFloat
-    @Binding var basicWords: [BasicWord]
-
+    @Binding var page: Page
+    
     var body: some View {
         GeometryReader { proxy in
             // ScrollView를 통해 PinchZoom시 좌우상하 이동
@@ -28,15 +28,14 @@ struct TestPageImageView: View {
                         height: max(uiImage?.size.height ?? proxy.size.height, proxy.size.height) * zoomScale
                     )
                     .overlay {
-                        ForEach(recognizedBoxes.indices, id: \.self) { index in
-                            let rect = recognizedBoxes[index]
-                            let box = adjustRect(rect.1, in: proxy)
+                        ForEach(page.sessions[0].words, id: \.self) { word in
+                            let box = adjustRect(word.rect, in: proxy)
                             @State var width = box.width
                             @State var height = box.height
                             @State var originX = box.origin.x
                             @State var originY = box.origin.y
 
-                            TextView(height: $height, width: $width, scale: $zoomScale)
+                            TextView(name: word.wordValue, height: $height, width: $width, scale: $zoomScale)
                                 .position(CGPoint(x: (originX + (width/2)), y: (originY + (height/2))))
                         }
                     }

--- a/Blank/Blank/View/TestPage/TestPagePinchZoomView.swift
+++ b/Blank/Blank/View/TestPage/TestPagePinchZoomView.swift
@@ -11,7 +11,7 @@ struct TestPagePinchZoomView: View {
 
     // Image 정보를 받을 수 있도록 프로퍼티 추가 - 경섭
     var image: UIImage?
-    @Binding var basicWords: [BasicWord]
+    @Binding var page: Page
 
     //
     @State private var scale: CGFloat = 1.0
@@ -37,7 +37,7 @@ struct TestPagePinchZoomView: View {
 
     var body: some View {
         // ImageView를 불러와서 Gesture 적용
-        TestPageImageView(uiImage: image, zoomScale: $scale, basicWords: $basicWords)
+        TestPageImageView(uiImage: image, zoomScale: $scale, page: $page)
             .gesture(magnification)
     }
     // 변경값을 lastScale에 저장하여 다음 확대시 lastScale에서부터 시작

--- a/Blank/Blank/View/TestPage/TestPageView.swift
+++ b/Blank/Blank/View/TestPage/TestPageView.swift
@@ -16,6 +16,8 @@ struct TestPageView: View {
     @State var type = ScrribleType.write
     @State private var hasTypeValueChanged = false
 
+    @State var page: Page
+
     var body: some View {
         NavigationStack {
             VStack {
@@ -44,7 +46,7 @@ struct TestPageView: View {
     
     private var testImage: some View{
         // TODO: 시험볼 page에 textfield를 좌표에 만들어 보여주기
-        TestPagePinchZoomView(image: generatedImage, basicWords: .constant([]))
+        TestPagePinchZoomView(image: generatedImage, page: $page)
     }
     
     private var backBtn: some View {


### PR DESCRIPTION
## 개요 및 관련 이슈
viewModal page구조체로 변경
(해당뷰)
OCREditView, TestView
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
OCREditView, TestView page 구조체로 변경
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
