### PR TITLE
[Feat] WordSelectView의 Alert을 Toast로 바꿈

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		42ED60D42ADE7F570043AF2F /* ResultPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42ED60D32ADE7F570043AF2F /* ResultPageView.swift */; };
 		42ED60D62ADE7F6C0043AF2F /* CorrectInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42ED60D52ADE7F6C0043AF2F /* CorrectInfoView.swift */; };
 		42ED60D82ADE7F910043AF2F /* PDFThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42ED60D72ADE7F910043AF2F /* PDFThumbnailView.swift */; };
+		4418D0432AEF99A7000EF661 /* PopupView in Frameworks */ = {isa = PBXBuildFile; productRef = 4418D0422AEF99A7000EF661 /* PopupView */; };
 		4491DFAA2ADD1E2E00CA5B42 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFA92ADD1E2E00CA5B42 /* HomeViewModel.swift */; };
 		4491DFEC2ADD4CF800CA5B42 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFEB2ADD4CF800CA5B42 /* Persistence.swift */; };
 		4491DFEF2ADD4D4700CA5B42 /* Blank.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFED2ADD4D4700CA5B42 /* Blank.xcdatamodeld */; };
@@ -138,6 +139,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4418D0432AEF99A7000EF661 /* PopupView in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,6 +358,9 @@
 			dependencies = (
 			);
 			name = Blank;
+			packageProductDependencies = (
+				4418D0422AEF99A7000EF661 /* PopupView */,
+			);
 			productName = Blank;
 			productReference = ACDBDA592AD7CC7600C44A80 /* Blank.app */;
 			productType = "com.apple.product-type.application";
@@ -384,6 +389,9 @@
 				Base,
 			);
 			mainGroup = ACDBDA502AD7CC7600C44A80;
+			packageReferences = (
+				4418D0412AEF99A6000EF661 /* XCRemoteSwiftPackageReference "PopupView" */,
+			);
 			productRefGroup = ACDBDA5A2AD7CC7600C44A80 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -688,6 +696,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		4418D0412AEF99A6000EF661 /* XCRemoteSwiftPackageReference "PopupView" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/exyte/PopupView.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.8.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		4418D0422AEF99A7000EF661 /* PopupView */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4418D0412AEF99A6000EF661 /* XCRemoteSwiftPackageReference "PopupView" */;
+			productName = PopupView;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		4491DFED2ADD4D4700CA5B42 /* Blank.xcdatamodeld */ = {

--- a/Blank/Blank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Blank/Blank.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "popupview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/PopupView.git",
+      "state" : {
+        "revision" : "bb18c1652f6b60741f9ff6ba4fb8569460a7ffaa",
+        "version" : "2.8.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import PopupView
 
 struct WordSelectView: View {
     @Environment(\.dismiss) private var dismiss
@@ -26,13 +27,13 @@ struct WordSelectView: View {
                 wordSelectImage
                 Spacer().frame(height : UIScreen.main.bounds.height * 0.12)
             }
-            .alert("단어를 터치해 주세요" ,isPresented: $showingAlert) {
-                Button("확인", role: .cancel) {
-                    
-                }
-            } message: {
-                Text("시험을 보고싶은 단어를 터치해주세요")
-            }
+            // .alert("단어를 터치해 주세요" ,isPresented: $showingAlert) {
+            //     Button("확인", role: .cancel) {
+            //         
+            //     }
+            // } message: {
+            //     Text("시험을 보고싶은 단어를 터치해주세요")
+            // }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     backBtn
@@ -51,7 +52,35 @@ struct WordSelectView: View {
         .navigationDestination(isPresented: $goToOCRView) {
             OCREditView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, overViewModel: overViewModel, page: $page)
         }
-        
+        .popup(isPresented: $showingAlert) {
+            HStack {
+                Image(systemName: "hand.tap.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 100)
+                    .foregroundStyle(.white)
+                    .padding()
+                VStack {
+                    Text("단어를 터치해 주세요.")
+                        .font(.largeTitle)
+                        .foregroundStyle(.white)
+                    Text("시험을 보고싶은 단어를 터치해주세요")
+                        .foregroundStyle(.white)
+                }
+                .padding()
+            }
+            .background(.black.opacity(0.8))
+            .clipShape(.rect(cornerRadius: 10))
+            .padding()
+            .offset(x: 0, y: 100)
+        } customize: {
+            $0
+                .position(.top)
+                .autohideIn(3.0)
+                .closeOnTap(false) // 팝업을 터치했을 때 없애야 하나?
+                .closeOnTapOutside(false)
+                .animation(.smooth)
+        }
     }
     
     private var wordSelectImage: some View {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- `WordSelectView`에서 현재 Alert을 토스트 헝태로 변경

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- `WordSelectView`에서 현재 Alert을 토스트 헝태로 변경
<img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN255eHk1b2oydmtocWd4dmk4am54ODlmZjlxdm94ZDhvd21tcTU3ayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tSjJMUaFChD2DlAdL3/giphy.gif">

## 참고 사항
- SPM 외부 라이브러리를 사용하였습니다: https://github.com/exyte/PopupView
