### PR TITLE
[Feat] 채점 로직 변경

### DIFF
--- a/Blank/Blank/ViewModel/ScoringViewModel.swift
+++ b/Blank/Blank/ViewModel/ScoringViewModel.swift
@@ -38,15 +38,20 @@ final class ScoringViewModel: ObservableObject {
         }
         
         currentWritingWords.enumerated().forEach { (index, currentWord) in
-            print("[DEBUG]", #function, index, currentWord)
-            // words[index].isCorrect = currentValue == words[index].wordValue
             let targetWordIndex = targetWords.firstIndex(where: { $0.id == currentWord.id })!
             print("[DEBUG]", currentWord.wordValue, targetWords[targetWordIndex].wordValue)
             print("[DEBUG]", targetWords[targetWordIndex].isCorrect)
             
-            // 채점 로직: 채점시에는 대소문자 구분없이 글자만 같으면 정답으로 처리한다.
-            let isCorrect = currentWord.wordValue.lowercased() == targetWords[targetWordIndex].wordValue.lowercased()
-            targetWords[targetWordIndex].isCorrect = isCorrect
+            // 채점 로직: 
+            // 1) 채점시에는 대소문자 구분없이 글자만 같으면 정답으로 처리한다.
+            // 2) 띄어쓰기 입력은 받되 채점시 고려안함
+            let currentWordValue = currentWord.wordValue
+                .lowercased()
+                .replacingOccurrences(of: " ", with: "")
+            let targetWordValue = targetWords[targetWordIndex].wordValue
+                .lowercased()
+                .replacingOccurrences(of: " ", with: "")
+            targetWords[targetWordIndex].isCorrect = currentWordValue == targetWordValue
         }
     }
     

--- a/Blank/Blank/ViewModel/ScoringViewModel.swift
+++ b/Blank/Blank/ViewModel/ScoringViewModel.swift
@@ -43,7 +43,10 @@ final class ScoringViewModel: ObservableObject {
             let targetWordIndex = targetWords.firstIndex(where: { $0.id == currentWord.id })!
             print("[DEBUG]", currentWord.wordValue, targetWords[targetWordIndex].wordValue)
             print("[DEBUG]", targetWords[targetWordIndex].isCorrect)
-            targetWords[targetWordIndex].isCorrect = currentWord.wordValue == targetWords[targetWordIndex].wordValue
+            
+            // 채점 로직: 채점시에는 대소문자 구분없이 글자만 같으면 정답으로 처리한다.
+            let isCorrect = currentWord.wordValue.lowercased() == targetWords[targetWordIndex].wordValue.lowercased()
+            targetWords[targetWordIndex].isCorrect = isCorrect
         }
     }
     

--- a/Blank/Blank/ViewModel/ScoringViewModel.swift
+++ b/Blank/Blank/ViewModel/ScoringViewModel.swift
@@ -39,19 +39,24 @@ final class ScoringViewModel: ObservableObject {
         
         currentWritingWords.enumerated().forEach { (index, currentWord) in
             let targetWordIndex = targetWords.firstIndex(where: { $0.id == currentWord.id })!
-            print("[DEBUG]", currentWord.wordValue, targetWords[targetWordIndex].wordValue)
-            print("[DEBUG]", targetWords[targetWordIndex].isCorrect)
             
-            // 채점 로직: 
+            // 채점 로직:
             // 1) 채점시에는 대소문자 구분없이 글자만 같으면 정답으로 처리한다.
             // 2) 띄어쓰기 입력은 받되 채점시 고려안함
+            // 3) [ . ] , [ , ] 도 입력은 받되 채점시 고려 안함
+            let replacingRegex = "([ .,…])"
+            
             let currentWordValue = currentWord.wordValue
                 .lowercased()
-                .replacingOccurrences(of: " ", with: "")
+                .replacingOccurrences(of: replacingRegex, with: "", options: .regularExpression)
             let targetWordValue = targetWords[targetWordIndex].wordValue
                 .lowercased()
-                .replacingOccurrences(of: " ", with: "")
+                .replacingOccurrences(of: replacingRegex, with: "", options: .regularExpression)
+            
             targetWords[targetWordIndex].isCorrect = currentWordValue == targetWordValue
+            
+            print("[DEBUG]", currentWordValue, targetWordValue)
+            print("[DEBUG]", targetWords[targetWordIndex].isCorrect)
         }
     }
     


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- 채점 로직 변경

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
 - 채점시에는 대소문자 구분없이 글자만 같으면 정답으로 처리한다.
 - 띄어쓰기 입력은 받되 채점시 고려안함,
 - `.` 과 `,` 및 `…`(점 세개 입력하면 자동 완성되는 문자) 도 입력은 받되 채점시 고려 안함

## 주요 로직(Optional)
```swift
// 채점 로직:
// 1) 채점시에는 대소문자 구분없이 글자만 같으면 정답으로 처리한다.
// 2) 띄어쓰기 입력은 받되 채점시 고려안함
// 3) [ . ] , [ , ] 도 입력은 받되 채점시 고려 안함
let replacingRegex = "([ .,…])"

let currentWordValue = currentWord.wordValue
    .lowercased()
    .replacingOccurrences(of: replacingRegex, with: "", options: .regularExpression)
let targetWordValue = targetWords[targetWordIndex].wordValue
    .lowercased()
    .replacingOccurrences(of: replacingRegex, with: "", options: .regularExpression)

targetWords[targetWordIndex].isCorrect = currentWordValue == targetWordValue
```
