### PR TITLE
[Fix] 페이지선택으로 이동 버튼 눌렀을때 앱이 꺼지는 버그 해결

### DIFF
--- a/Blank/Blank/Util/NavigatioinUtil.swift
+++ b/Blank/Blank/Util/NavigatioinUtil.swift
@@ -12,6 +12,17 @@ struct NavigationUtil {
         findNavigationController(viewController: UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.first { $0.isKeyWindow }?.rootViewController)?.popToRootViewController(animated: animated)
     }
     
+    static func popToOverView(animated: Bool = false) {
+            guard let navigationController = findNavigationController(viewController: UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.first { $0.isKeyWindow }?.rootViewController) else {
+                return
+            }
+            
+            if navigationController.viewControllers.count > 1 {
+                let overViewController = navigationController.viewControllers[1]  // 루트 뷰 바로 다음에 있는 뷰 컨트롤러를 가져옵니다.
+                navigationController.popToViewController(overViewController, animated: animated)
+            }
+        }
+    
     static func findNavigationController(viewController: UIViewController?) -> UINavigationController? {
         guard let viewController = viewController else {
             return nil

--- a/Blank/Blank/View/OverView/OverView.swift
+++ b/Blank/Blank/View/OverView/OverView.swift
@@ -91,16 +91,12 @@ struct OverView: View {
                     let wordSelectViewModel = WordSelectViewModel(page: page, basicWords: overViewModel.basicWords)
                     WordSelectView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, wordSelectViewModel: wordSelectViewModel)
                 } else {
-                    // let page = overViewModel.createNewPageAndSession()
-                    // let wordSelectViewModel = WordSelectViewModel(page: page, basicWords: overViewModel.basicWords)
-                    // WordSelectView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, wordSelectViewModel: wordSelectViewModel)
+                    
                     Text("Error")
                 }
                 
             } else {
-                // 나중에 조건 수정
-                //                let page = overViewModel.createNewPageAndSession()
-                //                TestPageView(isLinkActive: $isLinkActive, generatedImage: $generatedImage, page: page)
+            
             }
         }
         
@@ -235,7 +231,7 @@ struct OverView: View {
                     let percentageValue = overViewModel.statsOfSessions[overViewModel.sessions[index].id]?.correctRate.percentageTextValue(decimalPlaces: 0) ?? "0%"
                     Button("\(index + 1)회차 (\(percentageValue))") {
                         overViewModel.isTotalStatsViewMode = false
-                        let words = overViewModel.selectCurrentSessionAndWords(index: index)
+                        _ = overViewModel.selectCurrentSessionAndWords(index: index)
                     }
                 }
             } label: {

--- a/Blank/Blank/View/ResultPageView.swift
+++ b/Blank/Blank/View/ResultPageView.swift
@@ -96,7 +96,8 @@ struct ResultPageView: View {
     
     private var backToOverViewButton: some View {
         Button {
-            isLinkActive = false
+//            isLinkActive = false
+            NavigationUtil.popToOverView(animated: true)
         } label: {
             Text("페이지 선택으로 이동")
                 .fontWeight(.bold)


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
- 마지막페이지에서 '페이지 선택으로 이동'을 클릭시 앱이 종료되는 버그가 있어서, 이를 fix함
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
- 어디서 문제가 발생한 것인지 파악
- 코드 수정
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

## 주요 로직(Optional)
```diff
- print("변경 전")
+ static func popToOverView(animated: Bool = false) {
+            guard let navigationController = findNavigationController(viewController: +UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.first { $0.isKeyWindow +}?.rootViewController) else {
+               return
+            }
+            
+            if navigationController.viewControllers.count > 1 {
+                let overViewController = navigationController.viewControllers[1]  // 루트 뷰 바로 다음에 있는 뷰 컨트롤러를 가져옵니다.
+                navigationController.popToViewController(overViewController, animated: animated)
+            }
+        }
```
