### PR TITLE
93 feat bug textfield viewmodel 적용 및 버그 픽스

### DIFF
--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -12,8 +12,8 @@ struct OCREditView: View {
     @State private var showingModal = true
 //    @Binding var isLinkActive: Bool
     // @Binding var generatedImage: UIImage?
-    @State var visionStart: Bool = false
-    @State var type = ScrribleType.write
+//    @State var visionStart: Bool = false
+//    @State var type = ScrribleType.write
     @State private var hasTypeValueChanged = false
     @State private var goToTestPage = false
     
@@ -66,7 +66,7 @@ struct OCREditView: View {
     private var ocrEditImage: some View {
         // TODO: 텍스트필드를 사진 위에 올려서 확인할 텍스트와 함께 보여주기
         ZoomableContainer {
-            OCRImageView(uiImage: wordSelectViewModel.currentImage, zoomScale: .constant(1.0), words: $wordSelectViewModel.selectedWords)
+            OCRImageView(wordSelectViewModel: wordSelectViewModel)
         }
         
     }
@@ -86,7 +86,7 @@ struct OCREditView: View {
             Image(systemName: "questionmark.circle.fill")
         }
         .sheet(isPresented: $showingModal) {
-            ScrribleModalView(selectedType: $type, hasTypeValueChanged: $hasTypeValueChanged)
+            ScrribleModalView()
         }
     }
     

--- a/Blank/Blank/View/OCREdit/OCRImageView.swift
+++ b/Blank/Blank/View/OCREdit/OCRImageView.swift
@@ -8,60 +8,53 @@
 import SwiftUI
 
 struct OCRImageView: View {
-    
-    var uiImage: UIImage?
-//    @State private var recognizedBoxes: [(String, CGRect)] = []
+
+    //    @State private var recognizedBoxes: [(String, CGRect)] = []
     //경섭추가코드
-    @Binding var zoomScale: CGFloat
-    @Binding var words: [Word]
-    
+//    @State var words: [Word] = []
+
+    @StateObject var wordSelectViewModel: WordSelectViewModel
+
     var body: some View {
         GeometryReader { proxy in
             // ScrollView를 통해 PinchZoom시 좌우상하 이동
-                Image(uiImage: uiImage ?? UIImage())  //경섭추가코드를 받기위한 변경
-                    .resizable()
-                    .scaledToFit()
-                    .frame(
-                        
-                        width: max(uiImage?.size.width ?? proxy.size.width, proxy.size.width) * zoomScale,
-                        height: max(uiImage?.size.height ?? proxy.size.height, proxy.size.height) * zoomScale
-                    )
-                    .overlay {
-                        ForEach(words.indices, id: \.self) { index in
-                            let box = adjustRect(words[index].rect, in: proxy)
-                            @State var width = box.width
-                            @State var height = box.height
-                            @State var originX = box.origin.x
-                            @State var originY = box.origin.y
-                            @State var real = words[index].id
-                            
-                            TextView(name: $words[index].wordValue, height: $height, width: $width, scale: $zoomScale, orinX: $real)
-                                .position(CGPoint(x: (originX + (width / 2)), y: (originY + (height / 2 ))))
-                        }
+            Image(uiImage: wordSelectViewModel.currentImage ?? UIImage())  //경섭추가코드를 받기위한 변경
+                .resizable()
+                .scaledToFit()
+                .frame(
 
+                    width: max(wordSelectViewModel.currentImage?.size.width ?? proxy.size.width, proxy.size.width),
+                    height: max(wordSelectViewModel.currentImage?.size.height ?? proxy.size.height, proxy.size.height)
+                )
+                .overlay {
+                    // ForEach(page.sessions[0].words, id: \.self) { word in
+                    ForEach(wordSelectViewModel.selectedWords.indices, id: \.self) { index in
+                        let box = adjustRect(wordSelectViewModel.selectedWords[index].rect, in: proxy)
+                        let real = wordSelectViewModel.selectedWords[index].id
+                        TextView(name: $wordSelectViewModel.selectedWords[index].wordValue, height: box.height, width: box.width, orinX: real)
+                            .position(CGPoint(x: box.origin.x + (box.width / 2), y: (box.origin.y + (box.height / 2 ))))
                     }
-            
+                }
+
         }
     }
-    
+
     // ---------- Mark : 반자동   ----------------
     func adjustRect(_ rect: CGRect, in geometry: GeometryProxy) -> CGRect {
-        
-        let imageSize = self.uiImage?.size ?? CGSize(width: 1, height: 1)
-        
+
+        let zoomScale: CGFloat = 1.0
+
+        let imageSize = self.wordSelectViewModel.currentImage?.size ?? CGSize(width: 1, height: 1)
+
         let scaleY: CGFloat = geometry.size.height / imageSize.height
-        
+
         return CGRect(
-            
-            
+
+
             x: ( ( (geometry.size.width - imageSize.width) / 3.5 )  + (rect.origin.x * scaleY)) * zoomScale,
             y:( imageSize.height - rect.origin.y - rect.size.height) * scaleY * zoomScale,
             width: rect.width * scaleY * zoomScale,
             height : rect.height * scaleY * zoomScale
         )
     }
-}
-
-#Preview {
-    HomeView().environmentObject(HomeViewModel())
 }

--- a/Blank/Blank/View/OCREdit/ScrribleModalView.swift
+++ b/Blank/Blank/View/OCREdit/ScrribleModalView.swift
@@ -10,9 +10,9 @@ import AVKit
 
 struct ScrribleModalView: View {
     @Environment(\.dismiss) var dismiss
-    @Binding var selectedType: ScrribleType
-    @Binding var hasTypeValueChanged: Bool
-    @State var player: AVPlayer = AVPlayer(url: Bundle.main.url(forResource: "handWrite", withExtension: "mov")!)
+    @State var selectedType: ScrribleType = ScrribleType.write
+    @State var hasTypeValueChanged: Bool = false
+
     @State var text: String = ""
 
     var body: some View {
@@ -46,7 +46,7 @@ struct ScrribleModalView: View {
 
 
                 HStack(alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/) {
-                    ScrribleVideoView(player: $player, selectedType: $selectedType, hasTypeValueChanged: $hasTypeValueChanged)
+                    ScrribleVideoView(selectedType: $selectedType)
                         .padding()
                 }
                 .padding()
@@ -87,5 +87,5 @@ struct ScrribleModalView: View {
 }
 
 #Preview {
-    ScrribleModalView(selectedType: .constant(ScrribleType.write), hasTypeValueChanged: .constant(false))
+    ScrribleModalView()
 }

--- a/Blank/Blank/View/OCREdit/ScrribleVideoView.swift
+++ b/Blank/Blank/View/OCREdit/ScrribleVideoView.swift
@@ -9,38 +9,34 @@ import SwiftUI
 import AVKit
 
 struct ScrribleVideoView: View {
-    @Binding var player: AVPlayer
+//    @Binding var player: AVPlayer
+    @State var player: AVPlayer = AVPlayer(url: Bundle.main.url(forResource: "handWrite", withExtension: "mov")!)
     @Binding var selectedType: ScrribleType
-    @Binding var hasTypeValueChanged: Bool
-    
-    
-    
+
     var body: some View {
         VStack {
             PlayerUIView(player: player)
                 .frame(width: 600, height: 100)
                 .disabled(true)
                 .onAppear() {
-                    player = selectedType.video
+//                    player = selectedType.video
                     player.play()
-                    NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime, object: nil, queue: .main) { _ in
-                        player.seek(to: .zero)
-                        player.play()
-                    }
+//                    NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime, object: nil, queue: .main) { _ in
+//                        player.seek(to: .zero)
+//                        player.play()
+//                    }
                 }
-            
+
                 .onChange(of: selectedType) { newValue in
                     player = newValue.video
-//                    text = newValue.text.1
-                    NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime, object: nil, queue: .main) { _ in
-                        player.seek(to: .zero)
-                        player.play()
-                    }
+                    player.seek(to: .zero)
+                    player.play()
+
                 }
                 .onDisappear {
                     player.pause()
                     player.seek(to: .zero)
-                    
+
                 }
         }
     }

--- a/Blank/Blank/View/OCREdit/TextView.swift
+++ b/Blank/Blank/View/OCREdit/TextView.swift
@@ -10,14 +10,13 @@ import SwiftUI
 struct TextView: View {
     @State var isFocused: Bool = false
     @Binding var name: String
-    @Binding var height: CGFloat
-    @Binding var width: CGFloat
-    @Binding var scale: CGFloat
-    @Binding var orinX: UUID
+    var height: CGFloat
+    var width: CGFloat
+    var orinX: UUID
 
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
-            UITextViewRepresentable(text: $name, isFocused: $isFocused, height: $height)
+            UITextViewRepresentable(text: $name, isFocused: $isFocused, height: height)
                 .frame(width: width, height: height)
         }
         .border(isFocused ? Color.yellow : Color.blue, width: 1.5)
@@ -29,33 +28,30 @@ struct TextView: View {
 struct UITextViewRepresentable: UIViewRepresentable {
     @Binding var text: String
     @Binding var isFocused: Bool
-    @Binding var height: CGFloat
-    var fontSize: CGFloat = 1.9
+    var height: CGFloat
+    var fontScale: CGFloat = 1.9
 
     func makeUIView(context: UIViewRepresentableContext<UITextViewRepresentable>) -> UITextField {
         let textView = UITextField(frame: .zero)
 
-        textView.textAlignment = .center
+        textView.textAlignment = .left
         textView.delegate = context.coordinator
-        textView.font = UIFont(name: "Avenir", size: (height/fontSize))
-        textView.textAlignment = .center
+        textView.font = UIFont(name: "Avenir", size: (height/fontScale))
 //        textView.adjustsFontForContentSizeCategory = true
-        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+//        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         textView.adjustsFontSizeToFitWidth = true
         textView.autocapitalizationType = .none
-        textView.borderStyle = .none
-
-
-        textView.font = UIFont(name: "Avenir", size: height/1.9)
-        textView.sizeToFit()
+//        textView.borderStyle = .none
+//        textView.sizeToFit()
+        textView.addLeftPadding()
 
         return textView
     }
 
     func updateUIView(_ uiView: UITextField, context: Context) {
         uiView.text = text
-        uiView.setContentHuggingPriority(.defaultHigh, for: .vertical)
-        uiView.setContentCompressionResistancePriority(.required, for: .vertical)
+//        uiView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+//        uiView.setContentCompressionResistancePriority(.required, for: .vertical)
     }
 
     func makeCoordinator() -> UITextViewRepresentable.Coordinator {
@@ -81,4 +77,12 @@ struct UITextViewRepresentable: UIViewRepresentable {
             parent.isFocused = false
         }
      }
+}
+
+extension UITextField {
+    func addLeftPadding() {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: self.frame.height))
+        self.leftView = paddingView
+        self.leftViewMode = ViewMode.always
+    }
 }

--- a/Blank/Blank/View/TestPage/TestPageImageView.swift
+++ b/Blank/Blank/View/TestPage/TestPageImageView.swift
@@ -12,7 +12,7 @@ struct TestPageImageView: View {
     var uiImage: UIImage?
     //    @State private var recognizedBoxes: [(String, CGRect)] = []
     //경섭추가코드
-    @Binding var zoomScale: CGFloat
+    var zoomScale: CGFloat = 1.0
     @Binding var words: [Word]
     
     var body: some View {
@@ -23,8 +23,8 @@ struct TestPageImageView: View {
                 .scaledToFit()
                 .frame(
                     
-                    width: max(uiImage?.size.width ?? proxy.size.width, proxy.size.width) * zoomScale,
-                    height: max(uiImage?.size.height ?? proxy.size.height, proxy.size.height) * zoomScale
+                    width: max(uiImage?.size.width ?? proxy.size.width, proxy.size.width),
+                    height: max(uiImage?.size.height ?? proxy.size.height, proxy.size.height)
                 )
                 .overlay {
                     // ForEach(page.sessions[0].words, id: \.self) { word in
@@ -36,9 +36,9 @@ struct TestPageImageView: View {
                         @State var originY = box.origin.y
                         @State var real = words[index].id
                         
-                        TextView(name: $words[index].wordValue, height: $height, width: $width, scale: $zoomScale, orinX: $real)
+                        TextView(name: $words[index].wordValue, height: height, width: width, orinX: real)
                             .position(CGPoint(x: originX + (width / 2), y: (originY + (height / 2 ))))
-                            
+
                         //                            TextView(name: w.wordValue ,height: $height, width: $width, scale: $zoomScale, page: $page, originX: $real)
                         //                                .position(CGPoint(x: (originX + (width/2)), y: (originY + (height/2))))
                     }

--- a/Blank/Blank/View/TestPage/TestPageView.swift
+++ b/Blank/Blank/View/TestPage/TestPageView.swift
@@ -54,7 +54,7 @@ struct TestPageView: View {
         // TODO: 시험볼 page에 textfield를 좌표에 만들어 보여주기
 //        TestPagePinchZoomView(image: generatedImage, words: $scoringViewModel.currentWritingWords)
         ZoomableContainer {
-            TestPageImageView(uiImage: scoringViewModel.currentImage, zoomScale: .constant(1.0), words: $scoringViewModel.currentWritingWords)
+            TestPageImageView(uiImage: scoringViewModel.currentImage, words: $scoringViewModel.currentWritingWords)
         }
     }
     
@@ -73,7 +73,7 @@ struct TestPageView: View {
             Image(systemName: "questionmark.circle.fill")
         }
         .sheet(isPresented: $showingModal) {
-            ScrribleModalView(selectedType: $type, hasTypeValueChanged: $hasTypeValueChanged)
+            ScrribleModalView()
         }
     }
     


### PR DESCRIPTION
## 개요 및 관련 이슈
OCRImageView 및 TestPageImageView에서 TexiView 불러오는 방법 뷰모델 적용하여 변경
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
textView viewModel 인자로 변경 및 binding 필요 없는 값들은 binding 삭제하여 보라색 에러 삭제
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- textView 생성 시 뷰모델 활용
```swift
                .overlay {
                    ForEach(wordSelectViewModel.selectedWords.indices, id: \.self) { index in
                        let box = adjustRect(wordSelectViewModel.selectedWords[index].rect, in: proxy)
                        let real = wordSelectViewModel.selectedWords[index].id
                        TextView(name: $wordSelectViewModel.selectedWords[index].wordValue, height: box.height, width: box.width, orinX: real)
                            .position(CGPoint(x: box.origin.x + (box.width / 2), y: (box.origin.y + (box.height / 2 ))))
                    }
                }
```

- Binding 제거하여 보라색 에러문구 삭제
```swift
struct TextView: View {
    @State var isFocused: Bool = false
    @Binding var name: String
    var height: CGFloat // binding제거
    var width: CGFloat // binding제거
    var orinX: UUID // binding제거

    var body: some View {
        VStack(alignment: .center, spacing: 0) {
            UITextViewRepresentable(text: $name, isFocused: $isFocused, height: height)
                .frame(width: width, height: height)
        }
        .border(isFocused ? Color.yellow : Color.blue, width: 1.5)
        .background(Color.white)
    }
}

```
