### PR TITLE
[Feat] 워드셀렉트뷰에서 단어가 하나라도 선택되어야 다음 페이지로 이동가능하게 구현

### DIFF
--- a/Blank/Blank/View/ImageView.swift
+++ b/Blank/Blank/View/ImageView.swift
@@ -61,9 +61,6 @@ struct ImageView: View {
                             recognizeTextTwo(from: image) { recognizedTexts in
                                 self.recognizedBoxes = recognizedTexts
                                 basicWords = recognizedTexts.map { .init(id: UUID(), wordValue: $0.0, rect: $0.1, isSelectedWord: false) }
-                                //                                for (text, rect) in recognizedTexts {
-                                //                                    print("Text: \(text), Rect: \(rect)")
-                                //                                }
                             }
                         }
                     })
@@ -71,15 +68,7 @@ struct ImageView: View {
                     .overlay {
                         // TODO: Image 위에 올릴 컴포넌트(핀치줌 시 크기고정을 위해 width, height, x, y에 scale갑 곱하기)
                         
-                        if viewName == "OverView" {
-                            ForEach(recognizedBoxes.indices, id: \.self) { index in
-                                let box = recognizedBoxes[index]
-                                Rectangle()
-                                    .path(in:
-                                            adjustRect(box.1, in: proxy))
-                                    .stroke(Color.red, lineWidth: 1)
-                            }
-                        } else if viewName == "WordSelectView" {
+                        if viewName == "WordSelectView" {
                             
                             if let start = startLocation, let end = endLocation {
                                 Rectangle()
@@ -98,7 +87,7 @@ struct ImageView: View {
                                     }
                             }
                             
-            
+                            
                             
                         } else if viewName == "ResultPageView" {
                             // TargetWords의 wordValue에는 원래 값 + 맞고 틀림 여부(isCorrect)이 넘어온다
@@ -135,31 +124,31 @@ struct ImageView: View {
                     }
             } // 여기
             .gesture(
-            DragGesture()
-                .onChanged{ value in
-                    if startLocation == nil {
-                        startLocation = value.location
-                    }
-
-                    endLocation = value.location
-                    
-                    // 드래그 경로에 있는 단어 선택 1. rect구하기
-                    let dragRect = CGRect(x: min(startLocation!.x, endLocation!.x),
-                                          y: min(startLocation!.y, endLocation!.y),
-                                          width: abs(endLocation!.x - startLocation!.x),
-                                          height: abs(endLocation!.y - startLocation!.y))
-                    
-                    for index in basicWords.indices {
-                        if dragRect.intersects(adjustRect(basicWords[index].rect, in: proxy)) {
-                            basicWords[index].isSelectedWord = isSelectArea ? true : false
+                DragGesture()
+                    .onChanged{ value in
+                        if startLocation == nil {
+                            startLocation = value.location
+                        }
+                        
+                        endLocation = value.location
+                        
+                        // 드래그 경로에 있는 단어 선택 1. rect구하기
+                        let dragRect = CGRect(x: min(startLocation!.x, endLocation!.x),
+                                              y: min(startLocation!.y, endLocation!.y),
+                                              width: abs(endLocation!.x - startLocation!.x),
+                                              height: abs(endLocation!.y - startLocation!.y))
+                        
+                        for index in basicWords.indices {
+                            if dragRect.intersects(adjustRect(basicWords[index].rect, in: proxy)) {
+                                basicWords[index].isSelectedWord = isSelectArea ? true : false
+                            }
                         }
                     }
-                }
-                .onEnded{ value in
-                    // drag 끝나면 초기화
-                    startLocation = nil
-                    endLocation = nil
-                }
+                    .onEnded{ value in
+                        // drag 끝나면 초기화
+                        startLocation = nil
+                        endLocation = nil
+                    }
             )
         }
     }

--- a/Blank/Blank/View/OverView/OverViewModalView.swift
+++ b/Blank/Blank/View/OverView/OverViewModalView.swift
@@ -29,6 +29,7 @@ struct OverViewModalView: View {
                                     .shadow(color: Color.black.opacity(0.3), radius: 5, x: 0, y: 0)
                                     .onTapGesture {
                                         overViewModel.currentPage = index + 1
+                                        setImagesAndData()
                                         dismiss()
                                     }
                                 HStack {
@@ -103,6 +104,24 @@ struct OverViewModalView: View {
     }
 }
 
+extension OverViewModalView {
+    private func setImagesAndData() {
+        // 이미지를 영역에 표시
+        overViewModel.generateCurrentImage()
+        
+        DispatchQueue.global().async {
+            // 평균 1.5초 정도 소요
+            overViewModel.generateBasicWordsFromCurrentImage {
+                DispatchQueue.main.async {
+                    overViewModel.loadPage()
+                    overViewModel.loadSessionsOfPage()
+                }
+            }
+        }
+    }
+}
+
 //#Preview {
 //    OverViewModalView(viewModel: OverViewModel())
 //}
+

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -16,6 +16,7 @@ struct WordSelectView: View {
     @State var goToOCRView = false
     
     @State var isSelectArea = true
+    @State var noneOfWordSelected = true
     
     @ObservedObject var wordSelectViewModel: WordSelectViewModel
     
@@ -64,7 +65,6 @@ struct WordSelectView: View {
         .background(Color(.systemGray6))
         .navigationDestination(isPresented: $goToOCRView) {
             OCREditView(wordSelectViewModel: wordSelectViewModel)
-            
         }
         .popup(isPresented: $showingAlert) {
             HStack {
@@ -102,6 +102,9 @@ struct WordSelectView: View {
         VStack {
             ImageView(uiImage: wordSelectViewModel.currentImage, visionStart: $visionStart, viewName: "WordSelectView", isSelectArea: $isSelectArea, basicWords: $wordSelectViewModel.basicWords, targetWords: .constant([]), currentWritingWords: .constant([]))
         }
+        .onChange(of: wordSelectViewModel.basicWords) { _ in
+            noneOfWordSelected = !wordSelectViewModel.basicWords.contains(where: { $0.isSelectedWord })
+        }
     }
     
     private var backButton: some View {
@@ -126,6 +129,7 @@ struct WordSelectView: View {
                 .fontWeight(.bold)
         }
         .buttonStyle(.borderedProminent)
+        .disabled(noneOfWordSelected)
     }
     
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
- 워드셀렉트뷰에서 단어를 선택해야지 다음 뷰로 넘어갈 수 있게 설정했습니다.
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<image src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY3d3aWpicjR1bDgwOHQzNWIzcjBmZTd4dGtvd202d3J3czdkb3Q5biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/M7XPzewq5qgN1kOYY8/giphy.gif">
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
