### PR TITLE
[Feat] OverView에서 페이지 전환시 표시 영역 지움 + '원본' 기능 구현

### DIFF
--- a/Blank/Blank/View/OverView/OverView.swift
+++ b/Blank/Blank/View/OverView/OverView.swift
@@ -155,6 +155,7 @@ struct OverView: View {
                         .onTapGesture {
                             overViewModel.currentPage = index + 1
                             setImagesAndData()
+                            clearCorrectWordArea()
                         }
                     }
                     Spacer()
@@ -250,10 +251,7 @@ struct OverView: View {
                 ForEach(overViewModel.sessions.indices, id: \.self) { index in
                     let percentageValue = overViewModel.statsOfSessions[overViewModel.sessions[index].id]?.correctRate.percentageTextValue(decimalPlaces: 0) ?? "0%"
                     Button("\(index + 1)회차 (\(percentageValue))") {
-                        overViewModel.isTotalStatsViewMode = false
-                        _ = overViewModel.selectCurrentSessionAndWords(index: index)
-                        selectedSessionIndex = index
-                        seeResult = true
+                        setCorrectWordArea(index)
                     }
                 }
             } label: {
@@ -270,9 +268,9 @@ struct OverView: View {
             }
             
             Button {
-                // TODO: 원본 페이지 상태로 변경
                 seeResult = false
                 overViewModel.isTotalStatsViewMode = false
+                clearCorrectWordArea()
             } label: {
                 Text("원본")
             }
@@ -316,6 +314,21 @@ extension OverView {
                 }
             }
         }
+    }
+    
+    /// 회차가 변경되면 그 회차에 맞춰 단어 사각형 새로 그리기
+    private func setCorrectWordArea(_ index: Int) {
+        overViewModel.isTotalStatsViewMode = false
+        _ = overViewModel.selectCurrentSessionAndWords(index: index)
+        selectedSessionIndex = index
+        seeResult = true
+    }
+    
+    private func clearCorrectWordArea() {
+        overViewModel.isTotalStatsViewMode = false
+        overViewModel.currentSession = nil
+        selectedSessionIndex = nil
+        seeResult = false
     }
 }
 

--- a/Blank/Blank/ViewModel/OverViewModel.swift
+++ b/Blank/Blank/ViewModel/OverViewModel.swift
@@ -140,6 +140,12 @@ class OverViewModel: ObservableObject {
             
             sessions = try CDService.shared.loadAllSessions(of: selectedPage)
             print("[DEBUG] Loaded Sessions:", sessions.count)
+            
+            // 페이지 바뀔때는 wordsOfSession, statsOfSessions를 초기화
+            wordsOfSession = .init()
+            statsOfSessions = .init()
+            totalStats = .init()
+            
             sessions.forEach {
                 if let words = try? CDService.shared.loadAllWords(of: $0) {
                     wordsOfSession[$0.id] = words
@@ -152,7 +158,8 @@ class OverViewModel: ObservableObject {
                     )
                 }
             }
-            //마지막으로 시험 본 세션을 불러서 저장하는 코드
+            
+            // 마지막으로 시험 본 세션을 불러서 저장하는 코드
             if sessions.count >= 1 {
                 lastSession = sessions.last
             }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
#103 
- 원본 보기 기능
- 회차 기능 사용시 특정 회차를 선택한 상태에서 다른 페이지 섬네일을 터치한 경우 단어 표시 영역이 사라지지 않는 문제

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 원본 기능 구현
- 버그 픽스

https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/40187546/9cb98402-76ab-4d4a-8e89-aadb6b4d9a17


