### PR TITLE
[Fix] 오버뷰에서 키보드가 화면을 잡아먹으면서 뜨지 않게 버그 수정

### DIFF
--- a/Blank/Blank/View/OverView/OverView.swift
+++ b/Blank/Blank/View/OverView/OverView.swift
@@ -76,6 +76,7 @@ struct OverView: View {
             .navigationBarBackButtonHidden()
             .navigationTitle(titleName)
             .navigationBarTitleDisplayMode(.inline)
+            .ignoresSafeArea(.keyboard)
             
         }
         .navigationDestination(isPresented: $goToNextPage) {
@@ -200,6 +201,7 @@ struct OverView: View {
                     Spacer()
                     TextField("", text: $currentPageText, onCommit:{
                         overViewModel.updateCurrentPage(from: currentPageText)
+                        setImagesAndData()
                     })
                     .multilineTextAlignment(.trailing)
                     .keyboardType(.numberPad)
@@ -207,6 +209,7 @@ struct OverView: View {
                     Text(" / \(overViewModel.pdfTotalPage())")
                     Button {
                         overViewModel.updateCurrentPage(from: currentPageText)
+                        setImagesAndData()
                     } label: {
                         Text("이동")
                     }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
- 오버뮤에서 페이지를 텍스트필드에 입력할때 키보드가 올라와서 앱의 비율을 망치는 버그를 수정했습니다.
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<img width="620" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/612f3ba3-3fc3-4a91-8632-eb489fddf888">

<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
