### PR TITLE
[Bug]-fixed 단어 인식시 동일한 글자가 있을경우 좌표를 제대로 인식하지 못하는 버그 수정

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		ACDBDA5D2AD7CC7600C44A80 /* BlankApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDBDA5C2AD7CC7600C44A80 /* BlankApp.swift */; };
 		ACDBDA612AD7CC7700C44A80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACDBDA602AD7CC7700C44A80 /* Assets.xcassets */; };
 		ACDBDA642AD7CC7700C44A80 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACDBDA632AD7CC7700C44A80 /* Preview Assets.xcassets */; };
+		ACE0A6582AFA223B005031FE /* RecognizeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE0A6572AFA223B005031FE /* RecognizeText.swift */; };
 		ACF338C02ADD00DC004D20FC /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338BF2ADD00DC004D20FC /* File.swift */; };
 		ACF338C22ADD0136004D20FC /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C12ADD0136004D20FC /* Page.swift */; };
 		ACF338C42ADD0158004D20FC /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C32ADD0158004D20FC /* Session.swift */; };
@@ -118,6 +119,7 @@
 		ACDBDA5C2AD7CC7600C44A80 /* BlankApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlankApp.swift; sourceTree = "<group>"; };
 		ACDBDA602AD7CC7700C44A80 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		ACDBDA632AD7CC7700C44A80 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		ACE0A6572AFA223B005031FE /* RecognizeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizeText.swift; sourceTree = "<group>"; };
 		ACF338BF2ADD00DC004D20FC /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		ACF338C12ADD0136004D20FC /* Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
 		ACF338C32ADD0158004D20FC /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
@@ -232,6 +234,7 @@
 				449CB1E92ADEE0460086758A /* PDFUtil.swift */,
 				425D4E412AEF8EA800610BE8 /* ZoomableContainer.swift */,
 				425D4E452AF0EEEF00610BE8 /* NavigatioinUtil.swift */,
+				ACE0A6572AFA223B005031FE /* RecognizeText.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -491,6 +494,7 @@
 				42ED60D42ADE7F570043AF2F /* ResultPageView.swift in Sources */,
 				ACDBDA5D2AD7CC7600C44A80 /* BlankApp.swift in Sources */,
 				449CB1F02AE14A290086758A /* CGRect+.swift in Sources */,
+				ACE0A6582AFA223B005031FE /* RecognizeText.swift in Sources */,
 				4491DFF32ADD4EEB00CA5B42 /* PersistenceView.swift in Sources */,
 				EB69FC7D2AE6C71F00ADF7B6 /* TestPageImageView.swift in Sources */,
 				44A556742AE43774002AE4C3 /* Int+.swift in Sources */,

--- a/Blank/Blank/Util/RecognizeText.swift
+++ b/Blank/Blank/Util/RecognizeText.swift
@@ -1,0 +1,62 @@
+//
+//  RecognizeText.swift
+//  Blank
+//
+//  Created by Sup on 11/7/23.
+//
+
+import SwiftUI
+import Vision
+
+// completion은 recognizeText함수자체가 이미지에서 텍스트를 인식하는 비동기 작업을 수행하니까
+// 함수가 종료되었을 때가 아닌 작업이 완료되었을때 completion클로저를 호출해야됨
+func recognizeText(from image: UIImage, completion: @escaping ([(String, CGRect)]) -> Void) {
+    // 이미지 CGImage로 받음
+    guard let cgImage = image.cgImage else { return }
+    // VNImageRequestHandler옵션에 URL로 경로 할 수도 있고 화면회전에 대한 옵션도 가능
+    let requestHandler = VNImageRequestHandler(cgImage: cgImage)
+    
+    // 텍스트 인식 작업이 완료되었을때 실행할 클로저 정의
+    let request = VNRecognizeTextRequest { (request, error) in
+        var recognizedTexts: [(String, CGRect)] = [] // 단어랑 좌표값담을 빈 배열 튜플 생성
+        
+        if let results = request.results as? [VNRecognizedTextObservation] {
+            for observation in results {
+                if let topCandidate = observation.topCandidates(1).first {
+                    let words = topCandidate.string.split(separator: " ")
+                    // 동일한 순서의 글자(중복단어)가 있을경우 각 단어별로 고유한 좌표를 위한 세팅
+                    var currentPosition = topCandidate.string.startIndex
+                    
+                    for word in words {
+                        // 단어의 시작과 끝 위치를 찾습니다.
+                        if let wordRange = topCandidate.string.range(of: String(word),
+                                                                     range: currentPosition..<topCandidate.string.endIndex) {
+                            
+                            // 현재 위치를 다음 단어 검색을 위해 업데이트합니다.
+                            currentPosition = wordRange.upperBound
+                            
+                            if let box = try? topCandidate.boundingBox(for: wordRange) {
+                                let boundingBox = VNImageRectForNormalizedRect(box.boundingBox,
+                                                                               Int(image.size.width),
+                                                                               Int(image.size.height)
+                                )
+                                recognizedTexts.append((String(word), boundingBox))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        completion(recognizedTexts)
+    }
+    
+    request.recognitionLanguages = ["ko-KR"]
+    request.recognitionLevel = .accurate
+    request.minimumTextHeight = 0.01
+    
+    do {
+        try requestHandler.perform([request])
+    } catch {
+        print("Error performing text recognition request: \(error)")
+    }
+}

--- a/Blank/Blank/View/OverView/OverVIewImageView.swift
+++ b/Blank/Blank/View/OverView/OverVIewImageView.swift
@@ -74,8 +74,6 @@ struct OverViewImageView: View {
             height : rect.height * scaleY * zoomScale
         )
     }
-    
-    // => recognizeTextTwo는 OverViewModel로 이동하였습니다.
 }
 
 //

--- a/Blank/Blank/ViewModel/OverViewModel.swift
+++ b/Blank/Blank/ViewModel/OverViewModel.swift
@@ -47,7 +47,7 @@ class OverViewModel: ObservableObject {
                         fileId: currentFile.id,
                         currentPageNumber: currentPage
         )
-
+        
         return page
     }
     
@@ -85,7 +85,7 @@ class OverViewModel: ObservableObject {
         let session = self.lastSessionsOfPages[index]
         
         if let shelledSession = session,
-            let realSession = shelledSession,
+           let realSession = shelledSession,
            let words = try? CDService.shared.loadAllWords(of: realSession) {
             let correctCount = words.reduce(0) {
                 $0 + ($1.isCorrect ? 1 : 0)
@@ -270,58 +270,18 @@ class OverViewModel: ObservableObject {
         }
     }
     
-    // completion은 recognizeText함수자체가 이미지에서 텍스트를 인식하는 비동기 작업을 수행하니까
-    // 함수가 종료되었을 때가 아닌 작업이 완료되었을때 completion클로저를 호출해야됨
-    func recognizeTextTwo(from image: UIImage, completion: @escaping ([(String, CGRect)]) -> Void) {
-        // 이미지 CGImage로 받음
-        guard let cgImage = image.cgImage else { return }
-        // VNImageRequestHandler옵션에 URL로 경로 할 수도 있고 화면회전에 대한 옵션도 가능
-        let requestHandler = VNImageRequestHandler(cgImage: cgImage)
-        
-        // 텍스트 인식 작업이 완료되었을때 실행할 클로저 정의
-        let request = VNRecognizeTextRequest { (request, error) in
-            var recognizedTexts: [(String, CGRect)] = [] // 단어랑 좌표값담을 빈 배열 튜플 생성
-            
-            if let results = request.results as? [VNRecognizedTextObservation] {
-                for observation in results {
-                    if let topCandidate = observation.topCandidates(1).first {
-                        let words = topCandidate.string.split(separator: " ")
-                        
-                        for word in words {
-                            if let range = topCandidate.string.range(of: String(word)) {
-                                if let box = try? topCandidate.boundingBox(for: range) {
-                                    let boundingBox = VNImageRectForNormalizedRect(box.boundingBox, Int(image.size.width), Int(image.size.height))
-                                    recognizedTexts.append((String(word), boundingBox))
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            completion(recognizedTexts)
-        }
-        
-        request.recognitionLanguages = ["ko-KR"]
-        request.recognitionLevel = .accurate
-        request.minimumTextHeight = 0.01
-        
-        do {
-            try requestHandler.perform([request])
-        } catch {
-            print("Error performing text recognition request: \(error)")
-        }
-    }
-    
     /// currentImage로부터 basicWords를 생성
     func generateBasicWordsFromCurrentImage(completionHandler: (() -> Void)? = nil) {
         guard let currentImage else {
             return
         }
         
-        recognizeTextTwo(from: currentImage) { recognizedTexts in
+        
+        recognizeText(from: currentImage) { recognizedTexts in
             self.basicWords = recognizedTexts.map {
                 .init(id: UUID(), wordValue: $0.0, rect: $0.1, isSelectedWord: false)
             }
+            
             
             completionHandler?()
         }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- 기존 글자인식을 할 때 [ brown 밤색의 , 밤색 ] 이라는 글자들이 있으면 "밤색"이라는 글자가 동일한 단어로 인식해서
"밤색의" 와 "밤색" 이 동일 좌표를 갖게 됨
- 해당 글자들을 좌표를 각각 다르게 갖게 하려고 함

## 수정 전
![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2023-11-07 at 16 32 03](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/42464602/cda19a1c-e4aa-46fc-95fe-ac80976b2c30)
## 수정 후
![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2023-11-07 at 21 53 10](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/42464602/04a09019-f055-481e-90a2-1a03a13e5bae)



## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 로직 수정 
    - 단어마다 시작과 끝을 저장해서 단어별로 구별되게 함 
    - 구별된 단어를 바탕으로 인식 좌표를 할당
- 해당과정에서 RecognizeText함수를 global 함수의 형태로 별도 파일 생성 (RecognizeText.swift)
    - OverViewModel 의  RecognizeText함 수정 및 이동
        -  <img width="1495" alt="overViewModel 글자인식" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/42464602/bc433816-ccf9-473a-af54-9361dc689476">
    -  ImageView RecognizeText함 수정 및 이동
        - <img width="1484" alt="스크린샷 2023-11-07 오후 5 09 03" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/42464602/96eb1d29-45d2-440a-93fe-5d7eed67337f">


## 주요 로직 수정부분(Optional)
```diff
func recognizeText(from image: UIImage, completion: @escaping ([(String, CGRect)]) -> Void) {
   //// 기존코드들  ///
    let words = topCandidate.string.split(separator: " ")
        // 동일한 순서의 글자(중복단어)가 있을경우 각 단어별로 고유한 좌표를 위한 세팅
+        var currentPosition = topCandidate.string.startIndex

            for word in words {
                // 단어의 시작과 끝 위치를 찾습니다.
+                if let wordRange = topCandidate.string.range(of: String(word), range: currentPosition..<topCandidate.string.endIndex) {
                            
                        // 현재 위치를 다음 단어 검색을 위해 업데이트합니다.
+                        currentPosition = wordRange.upperBound
                            
+                        if let box = try? topCandidate.boundingBox(for: wordRange) {
                                        let boundingBox = VNImageRectForNormalizedRect(box.boundingBox,
                                        Int(image.size.width),
                                        Int(image.size.height)
                                    )

   //// 기존코드들  ///
```