### PR TITLE
[Enhancement] 글자 인식시 좌표 연산 부분 개선완료

### DIFF
--- a/Blank/Blank/Util/RecognizeText.swift
+++ b/Blank/Blank/Util/RecognizeText.swift
@@ -38,9 +38,16 @@ func recognizeText(from image: UIImage, completion: @escaping ([(String, CGRect)
                             if let box = try? topCandidate.boundingBox(for: wordRange) {
                                 let boundingBox = VNImageRectForNormalizedRect(box.boundingBox,
                                                                                Int(image.size.width),
-                                                                               Int(image.size.height)
+                                                                               Int(image.size.height))
+                                
+                                let changeFalotingToIntBox = CGRect(x: Int(round(boundingBox.origin.x)),
+                                                                    y: Int(round(boundingBox.origin.y)),
+                                                                    width: Int(round(boundingBox.width)),
+                                                                    height: Int(round(boundingBox.height))
                                 )
-                                recognizedTexts.append((String(word), boundingBox))
+                                
+                                
+                                recognizedTexts.append((String(word), changeFalotingToIntBox))
                             }
                         }
                     }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- 글자 인식시 좌표반환 값이 소수점 14자리까지 존재
- 연산으로 인한 앱실행시 발열의심
- 소수점 14자리를 잘라 연산을 감소시킴

### 수정전
<img width="662" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/42464602/71bacd8b-dc33-4d7a-a89a-484165d20b48">

### 수정후
<img width="377" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/42464602/1047e886-8fd5-42cc-9679-9b902873317e">

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 소수점 2,3자리 및 정수 일때 확인
    - 정수일때와 소수점일때 모두 빈칸 표시에 크게 영향이 없음
- 아예 정수로 하고 싶지만 CGRect자체가 Floating포인트를 가지고 있는 형태로 Struct를 구성해놓아서 소수점 1자리(0으로) 만듦 

## 추가 로직(Optional)
```diff
+ recognizeText()에 아래 내용 추가
let changeFalotingToIntBox = CGRect(
            x: Int(round(boundingBox.origin.x)),
            y: Int(round(boundingBox.origin.y)),
            width: Int(round(boundingBox.width)),
            height: Int(round(boundingBox.height))
            )
            
        recognizedTexts.append((String(word), changeFalotingToIntBox))
```
