### PR TITLE
[feat] pencil double tap시 단어선택- 선택지우기 버튼간 변환구현

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		ACDBDA612AD7CC7700C44A80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACDBDA602AD7CC7700C44A80 /* Assets.xcassets */; };
 		ACDBDA642AD7CC7700C44A80 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ACDBDA632AD7CC7700C44A80 /* Preview Assets.xcassets */; };
 		ACE0A6582AFA223B005031FE /* RecognizeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE0A6572AFA223B005031FE /* RecognizeText.swift */; };
+		ACE0A65A2AFAB117005031FE /* PencilDobuleTapInteractionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE0A6592AFAB117005031FE /* PencilDobuleTapInteractionView.swift */; };
 		ACF338C02ADD00DC004D20FC /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338BF2ADD00DC004D20FC /* File.swift */; };
 		ACF338C22ADD0136004D20FC /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C12ADD0136004D20FC /* Page.swift */; };
 		ACF338C42ADD0158004D20FC /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF338C32ADD0158004D20FC /* Session.swift */; };
@@ -120,6 +121,7 @@
 		ACDBDA602AD7CC7700C44A80 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		ACDBDA632AD7CC7700C44A80 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		ACE0A6572AFA223B005031FE /* RecognizeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizeText.swift; sourceTree = "<group>"; };
+		ACE0A6592AFAB117005031FE /* PencilDobuleTapInteractionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PencilDobuleTapInteractionView.swift; sourceTree = "<group>"; };
 		ACF338BF2ADD00DC004D20FC /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		ACF338C12ADD0136004D20FC /* Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
 		ACF338C32ADD0158004D20FC /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				425D4E412AEF8EA800610BE8 /* ZoomableContainer.swift */,
 				425D4E452AF0EEEF00610BE8 /* NavigatioinUtil.swift */,
 				ACE0A6572AFA223B005031FE /* RecognizeText.swift */,
+				ACE0A6592AFAB117005031FE /* PencilDobuleTapInteractionView.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -461,6 +464,7 @@
 				449CB1F72AE2BD1C0086758A /* CDService.swift in Sources */,
 				AC28517A2AE7292500C70F4F /* OverViewImageView.swift in Sources */,
 				EBEB727F2AE548C400316D66 /* ScribbleModalView.swift in Sources */,
+				ACE0A65A2AFAB117005031FE /* PencilDobuleTapInteractionView.swift in Sources */,
 				ACF338C42ADD0158004D20FC /* Session.swift in Sources */,
 				42ED60D82ADE7F910043AF2F /* PDFThumbnailView.swift in Sources */,
 				44F30BE62AE6781F00B67014 /* BasicWord.swift in Sources */,
@@ -636,7 +640,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Blank/Preview Content\"";
-				DEVELOPMENT_TEAM = TK7CS88A86;
+				DEVELOPMENT_TEAM = Q83JD2ZC9T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Blank/Info.plist;
@@ -673,7 +677,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Blank/Preview Content\"";
-				DEVELOPMENT_TEAM = TK7CS88A86;
+				DEVELOPMENT_TEAM = Q83JD2ZC9T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Blank/Info.plist;

--- a/Blank/Blank/Util/PencilDobuleTapInteractionView.swift
+++ b/Blank/Blank/Util/PencilDobuleTapInteractionView.swift
@@ -1,0 +1,76 @@
+//
+//  PencilDobuleTapInteractionView.swift
+//  Blank
+//
+//  Created by Sup on 11/8/23.
+//
+
+import SwiftUI
+import UIKit
+
+//  WordSelectView에서 pencil double탭시 선택 or 지우기 모드를 위한 구조체
+struct PencilDobuleTapInteractionView: UIViewRepresentable {
+    // 클로저를 사용하여 SwiftUI 뷰의 상태를 변경
+    var onDoubleTap: () -> Void
+    
+    // UIView를 생성하고 설정하는 메소드
+    func makeUIView(context: Context) -> UIView {
+        
+        // view를 사용할게 아니기 때문에 frame zero에 배경색을 투명하게 설정
+        let view = UIView()
+        view.backgroundColor = .clear
+        
+        // Apple Pencil interaction 객체를 생성하고 델리게이트를 설정
+        let pencilInteraction = UIPencilInteraction()
+        pencilInteraction.delegate = context.coordinator
+        view.addInteraction(pencilInteraction)
+        
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIView, context: Context) {
+        // 만약 UIView 업데이트 로직이 필요한 경우 여기에 구현
+        // 이번 구현에는 필요없기 때문에 공백
+    }
+    
+    // UIPencilInteractionDelegate 를 채택하는 Coordinator 클래스 구현
+    // onDoubleTap 을 채택해줘야 돌아감
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onDoubleTap: onDoubleTap)
+    }
+    
+    
+    // PencilInteractionView 내부에 Coordinator 클래스를 정의한다.
+    class Coordinator: NSObject, UIPencilInteractionDelegate {
+        var onDoubleTap: () -> Void // 더블 탭 시 실행할 클로저
+        
+        init(onDoubleTap: @escaping () -> Void) {
+            self.onDoubleTap = onDoubleTap
+        }
+        
+        
+        func pencilInteractionDidTap(_ interaction: UIPencilInteraction) {
+            // 더블 탭 발생 시 실행할 클로저
+            // 여기에 실제 기능을 넣는게 아니라 Dobule tap시 동작하길 원하는 기능이 있는 SwiftUI View에  PencilInteractionView을 넣어주면 된다
+            onDoubleTap()
+            
+            
+            
+            // ---------- Mark : 사용예시  ----------------
+            /* 사용예시
+             mark
+             아래 같은 방식으로 representable된 view을 사용해서 변화를 원하는 내용을 클로저에 담아주면 됨
+             
+             PencilDobuleTapInteractionView {
+             // 이 클로저는 Pencil의 더블 탭이 감지될 때 실행
+             self.isSelectArea.toggle()
+             }
+             .frame(width: 0, height: 0) // 뷰의 크기를 0으로 설정해서 눈에 안보이게
+             
+             */
+            // ----------   ----------------
+            
+        }
+    }
+}
+

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -25,6 +25,12 @@ struct WordSelectView: View {
             VStack {
                 wordSelectImage
                 Spacer().frame(height : UIScreen.main.bounds.height * 0.12)
+                PencilDobuleTapInteractionView {
+                    // 이 클로저는 pencil 더블 탭 시 실행
+                    self.isSelectArea.toggle()
+                        
+                }
+                .frame(width: 0, height: 0)
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
@@ -33,8 +39,8 @@ struct WordSelectView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     
                     HStack{
-
-                        // segment 버튼 
+                        
+                        // segment 버튼
                         Picker("도구 선택", selection: $isSelectArea) {
                             Image(systemName: "arrow.rectanglepath")
                                 .symbolRenderingMode(.monochrome)
@@ -46,6 +52,7 @@ struct WordSelectView: View {
                                 .foregroundStyle(.black)
                                 .tag(false)
                         }
+                        .id(isSelectArea)
                         .tint(.red)
                         .pickerStyle(.segmented)
                         


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
- 앱 사용시 pencil 사용이 필수
- pencil사용할 경우 일반적인 User는 pencil double tap을 자주 활용
- Word 선택 - 선택해제간에 버튼으로 전환이 아닌 Double Tap으로 전환기능 구현


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->
- 순수 SwiftUI만으로는 Pencil Double tap 구현불가
- UIKitRepresentable 방식으로 구현
- docs에 안내된 내용으로는 User의 탭 시 선호하는 동작을 먼저 확인하고 원하는 동작을 선택할 수 있게 해주는 방식을 추천
    - 그러나 우리 앱의 WordSelectView에서 단어선택 및 해제 전환간 별도의 동작을 사용자가 할 수 있는게 없으므로
    Double Tap시 버튼 toggle 기능으로 부여 

## 주요 로직(Optional)
- PencilDobuleTapInteractionView 파일 추가 
- WordSeleceView에 representable 내용 추가
   - 아래 코드는  WordSeleceView 추가 내용
```diff
PencilDobuleTapInteractionView {
    // 이 클로저는 pencil 더블 탭 시 실행
    self.isSelectArea.toggle()
    }
    .frame(width: 0, height: 0) // 뷰 자체 크기를 없애서 Double Tap동작에 대한 기능만 추가
```
