### PR TITLE
[Feat] 이미지 여백 늘리기 기능

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		444E6A632AF2535200AEC703 /* SessionStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444E6A622AF2535200AEC703 /* SessionStatistics.swift */; };
 		444E6A652AF2587000AEC703 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444E6A642AF2587000AEC703 /* Double.swift */; };
 		444E6A672AF26B1A00AEC703 /* WordStatistics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444E6A662AF26B1A00AEC703 /* WordStatistics.swift */; };
+		445F79682AFB89E6007D4998 /* ImageUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445F79672AFB89E6007D4998 /* ImageUtil.swift */; };
 		4491DFAA2ADD1E2E00CA5B42 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFA92ADD1E2E00CA5B42 /* HomeViewModel.swift */; };
 		4491DFEC2ADD4CF800CA5B42 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFEB2ADD4CF800CA5B42 /* Persistence.swift */; };
 		4491DFEF2ADD4D4700CA5B42 /* Blank.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 4491DFED2ADD4D4700CA5B42 /* Blank.xcdatamodeld */; };
@@ -92,6 +93,7 @@
 		444E6A622AF2535200AEC703 /* SessionStatistics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStatistics.swift; sourceTree = "<group>"; };
 		444E6A642AF2587000AEC703 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
 		444E6A662AF26B1A00AEC703 /* WordStatistics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordStatistics.swift; sourceTree = "<group>"; };
+		445F79672AFB89E6007D4998 /* ImageUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUtil.swift; sourceTree = "<group>"; };
 		4491DFA92ADD1E2E00CA5B42 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		4491DFEB2ADD4CF800CA5B42 /* Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		4491DFEE2ADD4D4700CA5B42 /* Blank.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Blank.xcdatamodel; sourceTree = "<group>"; };
@@ -234,6 +236,7 @@
 			isa = PBXGroup;
 			children = (
 				449CB1E92ADEE0460086758A /* PDFUtil.swift */,
+				445F79672AFB89E6007D4998 /* ImageUtil.swift */,
 				425D4E412AEF8EA800610BE8 /* ZoomableContainer.swift */,
 				425D4E452AF0EEEF00610BE8 /* NavigatioinUtil.swift */,
 				ACE0A6572AFA223B005031FE /* RecognizeText.swift */,
@@ -490,6 +493,7 @@
 				449CB1EA2ADEE0460086758A /* PDFUtil.swift in Sources */,
 				42ED60C62ADE7EDB0043AF2F /* HomeView.swift in Sources */,
 				44F30BE42AE6738000B67014 /* WordSelectViewModel.swift in Sources */,
+				445F79682AFB89E6007D4998 /* ImageUtil.swift in Sources */,
 				4491DFEF2ADD4D4700CA5B42 /* Blank.xcdatamodeld in Sources */,
 				449CB1DA2ADED6C10086758A /* DocumentPickerRepresentedView.swift in Sources */,
 				42E7638A2AE1229700624D81 /* OverViewModel.swift in Sources */,
@@ -640,7 +644,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Blank/Preview Content\"";
-				DEVELOPMENT_TEAM = Q83JD2ZC9T;
+				DEVELOPMENT_TEAM = 6S2SA26VAN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Blank/Info.plist;
@@ -677,7 +681,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Blank/Preview Content\"";
-				DEVELOPMENT_TEAM = Q83JD2ZC9T;
+				DEVELOPMENT_TEAM = 6S2SA26VAN;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Blank/Info.plist;

--- a/Blank/Blank/BlankApp.swift
+++ b/Blank/Blank/BlankApp.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 @main
 struct BlankApp: App {
-    let persistenceController = PersistenceController.shared
-    
     init() {
         HomeViewModel.copySampleFiles()
     }
@@ -18,10 +16,6 @@ struct BlankApp: App {
     var body: some Scene {
         WindowGroup {
             HomeView()
-                .environment(
-                    \.managedObjectContext,
-                     persistenceController.container.viewContext
-                )
         }
     }
 }

--- a/Blank/Blank/Util/ImageUtil.swift
+++ b/Blank/Blank/Util/ImageUtil.swift
@@ -5,4 +5,30 @@
 //  Created by 윤범태 on 2023/11/08.
 //
 
-import Foundation
+import UIKit
+
+func resizeImage(image: UIImage, targetSize: CGSize) -> UIImage? {
+    let size = image.size
+    
+    let widthRatio  = targetSize.width  / size.width
+    let heightRatio = targetSize.height / size.height
+    
+    // Figure out what our orientation is, and use that to form the rectangle
+    var newSize: CGSize
+    if(widthRatio > heightRatio) {
+        newSize = CGSize(width: size.width * heightRatio, height: size.height * heightRatio)
+    } else {
+        newSize = CGSize(width: size.width * widthRatio, height: size.height * widthRatio)
+    }
+    
+    // This is the rect that we've calculated out and this is what is actually used below
+    let rect = CGRect(origin: .zero, size: newSize)
+    
+    // Actually do the resizing to the rect using the ImageContext stuff
+    UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+    image.draw(in: rect)
+    let newImage = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    
+    return newImage
+}

--- a/Blank/Blank/Util/ImageUtil.swift
+++ b/Blank/Blank/Util/ImageUtil.swift
@@ -1,0 +1,8 @@
+//
+//  ImageUtil.swift
+//  Blank
+//
+//  Created by 윤범태 on 2023/11/08.
+//
+
+import Foundation

--- a/Blank/Blank/Util/RecognizeText.swift
+++ b/Blank/Blank/Util/RecognizeText.swift
@@ -44,8 +44,9 @@ func recognizeText(from image: UIImage, completion: @escaping ([(String, CGRect)
                                                                     y: Int(round(boundingBox.origin.y)),
                                                                     width: Int(round(boundingBox.width)),
                                                                     height: Int(round(boundingBox.height))
+                                                                    
+                                                                    
                                 )
-                                
                                 
                                 recognizedTexts.append((String(word), changeFalotingToIntBox))
                             }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
#117 
- 이미지 불러올 시 비율 일정하게(안정된 비율 => A4로 설정했습니다.)
- **가로가 더 긴 페이지를 불러와도 정상 작동해서 막기 기능은 넣지 않았습니다.**

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

- 이미지로 로딩시 비율 맞추기

## 주요 로직(Optional)
- OverViewModel의 generateCurrentImage() 의 maxWidth를 더 낮게 조정하면 보다 정확한 area 값을 얻을 수 있습니다. 
  - 그만큼 해상도는 더 낮아집니다.

```swift
    func generateCurrentImage() {
        guard let page = pdfDocument.page(at: currentPage - 1) else {
            return
        }
        
        // TODO: - 더 큰 해상도도 정확히 인식할 수 있어야 함
        // 현재 가로 해상도 최대 600을 넘어가면 범위 어긋남
        let maxWidth: CGFloat = 620 // 최대 크기를 더 늘릴 수 있다면 늘려보기
        let maxHeight: CGFloat = maxWidth * 1.414
```
### 예제 파일들의 width 수치 
```plain
samplepdf.pdf
pageRect.size (612.0, 864.0)
height = width * 1.4117647059

toeic.pdf
pageRect.size (595.32, 841.9200000000001)
height = width * 1.4142310018

elementarySchool.pdf
pageRect.size (595.5, 842.25)
height = width * 1.4143576826

sample.pdf
pageRect.size (595.2756, 841.8898)
height = 1.414

A4
height = width * 1.4142857143
```