### PR TITLE
[Fix] loadLastSessionNumber 배열 범위초과 에러 해결

### DIFF
--- a/Blank/Blank/ViewModel/OverViewModel.swift
+++ b/Blank/Blank/ViewModel/OverViewModel.swift
@@ -56,13 +56,15 @@ class OverViewModel: ObservableObject {
         do {
             if let loadedFile = try CDService.shared.readFile(from: currentFile.fileURL.lastPathComponent) {
                 let pages = try CDService.shared.readAllPages(fileId: loadedFile.id)
-                let page = pages[index]
-                let lastSessionNumber = try CDService.shared.loadAllSessions(of: page).count
-                return lastSessionNumber
+                if let page = pages.first(where: { $0.currentPageNumber == index + 1} ) {
+                    let lastSessionNumber = try CDService.shared.loadAllSessions(of: page).count
+                    return lastSessionNumber
+                }
             }
         } catch {
             print(#function, error)
         }
+        
         return 0
     }
     


### PR DESCRIPTION
(cherry picked from commit ccabbfec0ffeede3373fd724918ea084f2c73a30)

## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->
#124 

## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

<img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExczR1OWY5cGJiMmZtenkxaWF0cTIzdGV2aDl4djl0eTNkcWd4b3gxbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/HAIYIcY3r53Y4vzgfQ/giphy.gif">

## 주요 로직(Optional)
```diff
- let page = pages[index]
- let lastSessionNumber = try CDService.shared.loadAllSessions(of: page).count
- return lastSessionNumber
+ if let page = pages.first(where: { $0.currentPageNumber == index + 1} ) {
+    let lastSessionNumber = try CDService.shared.loadAllSessions(of: page).count
+    return lastSessionNumber
+  }
```
