### PR TITLE
#146 design 뷰제목 및 알러트 단어 바꾸기

### DIFF
--- a/Blank/Blank.xcodeproj/project.pbxproj
+++ b/Blank/Blank.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		422355C72B0CA54300905F76 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422355C62B0CA54300905F76 /* Color+.swift */; };
 		425D4E422AEF8EA800610BE8 /* ZoomableContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425D4E412AEF8EA800610BE8 /* ZoomableContainer.swift */; };
 		425D4E462AF0EEEF00610BE8 /* NavigationUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425D4E452AF0EEEF00610BE8 /* NavigationUtil.swift */; };
 		42E7638A2AE1229700624D81 /* OverViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E763892AE1229700624D81 /* OverViewModel.swift */; };
@@ -79,6 +80,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		422355C62B0CA54300905F76 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		425D4E412AEF8EA800610BE8 /* ZoomableContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableContainer.swift; sourceTree = "<group>"; };
 		425D4E452AF0EEEF00610BE8 /* NavigationUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationUtil.swift; sourceTree = "<group>"; };
 		42E763892AE1229700624D81 /* OverViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverViewModel.swift; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				44A556752AE52990002AE4C3 /* String+.swift */,
 				444E6A642AF2587000AEC703 /* Double.swift */,
 				EB3EBD0D2B075F0E001160B0 /* View+.swift */,
+				422355C62B0CA54300905F76 /* Color+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 				425D4E422AEF8EA800610BE8 /* ZoomableContainer.swift in Sources */,
 				ACF338C22ADD0136004D20FC /* Page.swift in Sources */,
 				449F7A9A2B05F924003425AF /* Folder.swift in Sources */,
+				422355C72B0CA54300905F76 /* Color+.swift in Sources */,
 				44F30BE22AE579E200B67014 /* APICRUDView.swift in Sources */,
 				EB8978FB2AE6A0BC00494BE7 /* TextView.swift in Sources */,
 				42ED60CA2ADE7F090043AF2F /* OverViewModalView.swift in Sources */,
@@ -676,7 +680,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"Blank/Preview Content\"";
-				DEVELOPMENT_TEAM = 6S2SA26VAN;
 				DEVELOPMENT_TEAM = HR74YJR7W4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -715,7 +718,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"Blank/Preview Content\"";
-				DEVELOPMENT_TEAM = 6S2SA26VAN;
 				DEVELOPMENT_TEAM = HR74YJR7W4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Blank/Blank/Extension/Color+.swift
+++ b/Blank/Blank/Extension/Color+.swift
@@ -1,0 +1,32 @@
+//
+//  ColorExtension.swift
+//  Blank
+//
+//  Created by Greed on 11/21/23.
+//
+
+import SwiftUI
+
+extension Color {
+    
+    static let correctColor = Color(hex: "AEF894")
+    static let wrongColor = Color(hex: "FDA5A5")
+    static let flippedAreaColor = Color(hex: "EEEEEE")
+
+}
+
+extension Color {
+    init(hex: String) {
+        let scanner = Scanner(string: hex)
+        _ = scanner.scanString("#")
+        
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+        
+        let r = Double((rgb >> 16) & 0xFF) / 255.0
+        let g = Double((rgb >>  8) & 0xFF) / 255.0
+        let b = Double((rgb >>  0) & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}
+

--- a/Blank/Blank/View/ImageView.swift
+++ b/Blank/Blank/View/ImageView.swift
@@ -95,13 +95,13 @@ struct ImageView: View {
                             let originalValue = targetWords[index].wordValue
                             let wroteValue = currentWritingWords[index].wordValue
                             
-                            let correctColor = Color(red: 183 / 255, green: 255 / 255, blue: 157 / 255) // Color.green.opacity(0.4)
-                            let wrongColor = Color(red: 253 / 255, green: 169 / 255, blue: 169 / 255) // Color.red.opacity(0.4)
-                            let flippedAreaColor = Color(white: 238/255)
+//                            let correctColor = Color(red: 183 / 255, green: 255 / 255, blue: 157 / 255) // Color.green.opacity(0.4)
+//                            let wrongColor = Color(red: 253 / 255, green: 169 / 255, blue: 169 / 255) // Color.red.opacity(0.4)
+//                            let flippedAreaColor = Color(white: 238/255)
                             
                             RoundedRectangle(cornerSize: .init(width: cornerRadiusSize, height: cornerRadiusSize))
                                 .path(in: adjustRect)
-                                .fill(isCorrect ? correctColor : isAreaTouched[index, default: false] ? flippedAreaColor : wrongColor)
+                                .fill(isCorrect ? Color.correctColor : isAreaTouched[index, default: false] ? Color.flippedAreaColor : Color.wrongColor)
                                 .shadow(color: isCorrect ? .clear : .black.opacity(0.4), radius: 4, x: 0, y: 1)
                                 .overlay(
                                     Text("\(isCorrect ? originalValue : isAreaTouched[index, default: false] ? originalValue : wroteValue)")

--- a/Blank/Blank/View/ImageView.swift
+++ b/Blank/Blank/View/ImageView.swift
@@ -30,7 +30,7 @@ struct ImageView: View {
     
     @State var isAreaTouched: [Int: Bool] = [:]
     
-    let cornerRadiusSize: CGFloat = 6
+    let cornerRadiusSize: CGFloat = 5
     let fontSizeRatio: CGFloat = 1.9
     
     @State var zoomScale: CGFloat = 1.0
@@ -102,7 +102,7 @@ struct ImageView: View {
                             RoundedRectangle(cornerSize: .init(width: cornerRadiusSize, height: cornerRadiusSize))
                                 .path(in: adjustRect)
                                 .fill(isCorrect ? correctColor : isAreaTouched[index, default: false] ? flippedAreaColor : wrongColor)
-                                .shadow(color: isCorrect ? .clear : .black, radius: 2, x: 2, y: 2)
+                                .shadow(color: isCorrect ? .clear : .black.opacity(0.4), radius: 4, x: 0, y: 1)
                                 .overlay(
                                     Text("\(isCorrect ? originalValue : isAreaTouched[index, default: false] ? originalValue : wroteValue)")
                                         .font(.system(size: adjustRect.height / fontSizeRatio, weight: .semibold))

--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -66,7 +66,7 @@ struct OCREditView: View {
             )
         }
         .ignoresSafeArea(.keyboard)
-        .background(Color(.systemGray6))
+        .background(Color(.systemGray4))
         .popup(isPresented: $showingAlert) {
             HStack {
                 Image("pencil.and.scribble")

--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -79,11 +79,7 @@ struct OCREditView: View {
                     .padding()
                 VStack {
                     Text("잘못 인식된 글자를 수정해주세요.")
-                        .font(.headline)
-                        .foregroundStyle(.white)
-                    
-                    Text("잘못 인식된 글자가 있다면 수정해주세요.")
-                        .font(.subheadline)
+                        .font(.largeTitle)
                         .foregroundStyle(.white)
                 }
                 .padding()

--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 struct OCREditView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showingModal = false
-//    @Binding var isLinkActive: Bool
+    //    @Binding var isLinkActive: Bool
     // @Binding var generatedImage: UIImage?
     @State private var showingAlert = true
     @State var visionStart: Bool = false
     @State private var goToTestPage = false
     @State var isShowingButton = true
-
+    
     @StateObject var wordSelectViewModel: WordSelectViewModel
     
     /*
@@ -32,7 +32,7 @@ struct OCREditView: View {
                         hideKeyboard()
                     }
                 Spacer().frame(height : UIScreen.main.bounds.height * 0.12)
-
+                
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
@@ -76,19 +76,13 @@ struct OCREditView: View {
                     .foregroundStyle(.white)
                     .padding()
                 VStack {
-                    Text("Pencil을 활용해 빈칸을 채워보세요")
+                    Text("잘못 인식된 글자를 수정해주세요.")
                         .font(.headline)
                         .foregroundStyle(.white)
-                    HStack {
-                        Text("자세한 내용은 우측 상단에")
-                            .font(.subheadline)
-                            .foregroundStyle(.white)
-                        Image(systemName: "questionmark.circle.fill")
-                            .foregroundStyle(.white)
-                        Text("클릭해주세요")
-                            .font(.subheadline)
-                            .foregroundStyle(.white)
-                    }
+                    
+                    Text("잘못 인식된 글자가 있다면 수정해주세요.")
+                        .font(.subheadline)
+                        .foregroundStyle(.white)
                 }
                 .padding()
             }
@@ -104,7 +98,7 @@ struct OCREditView: View {
                 .closeOnTapOutside(false)
                 .animation(.smooth)
         }
-
+        
     }
     
     private var ocrEditImage: some View {
@@ -128,9 +122,9 @@ struct OCREditView: View {
             Image(systemName: "questionmark.circle.fill")
         }
         .sheet(isPresented: $showingModal) {
-
+            
             ScribbleModalView()
-
+            
         }
     }
     
@@ -144,7 +138,7 @@ struct OCREditView: View {
         }
         .buttonStyle(.borderedProminent)
     }
-
+    
     private var showOriginalImageButton: some View {
         Button {
             wordSelectViewModel.isOrginal.toggle()

--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -51,7 +51,7 @@ struct OCREditView: View {
             }
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarBackground(.blue.opacity(0.2), for: .navigationBar)
-            .navigationTitle("오타수정")
+            .navigationTitle("오타 수정")
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden()
         }

--- a/Blank/Blank/View/OCREdit/OCREditView.swift
+++ b/Blank/Blank/View/OCREdit/OCREditView.swift
@@ -16,6 +16,7 @@ struct OCREditView: View {
     @State var visionStart: Bool = false
     @State private var goToTestPage = false
     @State var isShowingButton = true
+    var sessionNum: Int
     
     @StateObject var wordSelectViewModel: WordSelectViewModel
     
@@ -56,6 +57,7 @@ struct OCREditView: View {
         }
         .navigationDestination(isPresented: $goToTestPage) {
             TestPageView(
+                sessionNum: sessionNum, 
                 scoringViewModel: .init(
                     page: wordSelectViewModel.page,
                     session: wordSelectViewModel.session,

--- a/Blank/Blank/View/OverView/OverView.swift
+++ b/Blank/Blank/View/OverView/OverView.swift
@@ -108,12 +108,12 @@ struct OverView: View {
                 )
             }
         }
-        .alert("시험지 선택" ,isPresented: $showingAlert) {
-            Button("마지막 회차 다시 보기") {
-                goToTestPage = true
+        .alert("어떤 시험지를 고르시겠어요?" ,isPresented: $showingAlert) {
+            Button("새로 만들기") {
                 goToNextPage = true
             }
-            Button("새 빈칸 시험지 만들기") {
+            Button("시험 보기") {
+                goToTestPage = true
                 goToNextPage = true
             }
             Button("취소", role: .cancel) {
@@ -121,24 +121,11 @@ struct OverView: View {
             }
         } message: {
             Text("""
-                 기존에 시험을 본 내용이 있습니다.
-                 마지막 회차 시험을 바로 보시겠습니까?
-                 새로 빈칸 시험지를 만드시겠습니까?
+                 새로운 빈칸을 만들거나,
+                 지난 회차 시험을 볼 수 있습니다.
                  """)
         }
     }
-    
-    // private var progressStatus: some View {
-    //     VStack(spacing: 20) {
-    //         ProgressView(value: overViewModel.currentProgress)
-    //             .progressViewStyle(CircularProgressViewStyle(tint: .blue))
-    //         
-    //         Text("파일을 로딩 중 입니다.")
-    //         
-    //         Text("\(Int(overViewModel.currentProgress * 100))%") // 퍼센트로 변환하여 표시
-    //     }
-    //     .background(.white)
-    // }
     
     private var bottomScrollView: some View {
         ScrollView(.horizontal, showsIndicators: true) {
@@ -300,7 +287,7 @@ struct OverView: View {
     
     private var showOriginalImageButton: some View {
         VStack {
-            if seeResult {
+            if seeResult || overViewModel.isTotalStatsViewMode {
                 Button {
                     seeResult = false
                     overViewModel.isTotalStatsViewMode = false
@@ -329,7 +316,7 @@ struct OverView: View {
                 goToNextPage = true
             }
         } label: {
-            Text("시험준비")
+            Text("빈칸 만들기")
                 .fontWeight(.bold)
         }
         .buttonStyle(.borderedProminent)

--- a/Blank/Blank/View/OverView/OverView.swift
+++ b/Blank/Blank/View/OverView/OverView.swift
@@ -88,7 +88,7 @@ struct OverView: View {
                 // TODO: - 이미 생성한 페이지라면 다시 생성되지 않게 해야됨, CoreData에서 페이지 있는지 검사
                 if let page = overViewModel.selectedPage {
                     let wordSelectViewModel = WordSelectViewModel(page: page, basicWords: overViewModel.basicWords, currentImage: overViewModel.currentImage)
-                    WordSelectView( wordSelectViewModel: wordSelectViewModel)
+                    WordSelectView( sessionNum: overViewModel.sessions.count + 1, wordSelectViewModel: wordSelectViewModel)
                 } else {
                     Text("Error")
                 }
@@ -98,6 +98,7 @@ struct OverView: View {
                 let wordSelectViewModel = WordSelectViewModel(page: page, basicWords: overViewModel.basicWords)
                 
                 TestPageView(
+                    sessionNum: overViewModel.sessions.count + 1, 
                     scoringViewModel: .init(
                         page: wordSelectViewModel.page,
                         session: wordSelectViewModel.session,

--- a/Blank/Blank/View/OverView/OverViewModalView.swift
+++ b/Blank/Blank/View/OverView/OverViewModalView.swift
@@ -88,7 +88,7 @@ struct OverViewModalView: View {
                 }
             }
             .padding()
-            .background(Color(.systemGray5))
+            .background(Color(.systemGray4))
             .toolbar {
                 Button(action: {
                     dismiss()

--- a/Blank/Blank/View/ResultPage/ResultPageView.swift
+++ b/Blank/Blank/View/ResultPage/ResultPageView.swift
@@ -41,7 +41,7 @@ struct ResultPageView: View {
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden()
         }
-        .background(Color(.systemGray6))
+        .background(Color(.systemGray4))
         .onAppear {
             scoringViewModel.score()
             scoringViewModel.saveSessionToDatabase()

--- a/Blank/Blank/View/TestPage/TestPageView.swift
+++ b/Blank/Blank/View/TestPage/TestPageView.swift
@@ -15,6 +15,7 @@ struct TestPageView: View {
     @State var type = ScribbleType.write
     @State private var hasTypeValueChanged = false
     @State private var goToResultPage = false
+    var sessionNum: Int
     
     @StateObject var scoringViewModel: ScoringViewModel
     
@@ -40,7 +41,7 @@ struct TestPageView: View {
             }
             .toolbarBackground(.visible, for: .navigationBar)
             .toolbarBackground(.blue.opacity(0.2), for: .navigationBar)
-            .navigationTitle("시험")
+            .navigationTitle("\(sessionNum)회차 시험지")
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden()
         }

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -71,7 +71,7 @@ struct WordSelectView: View {
             .navigationTitle("단어 선택")
             .navigationBarTitleDisplayMode(.inline)
         }
-        .background(Color(.systemGray6))
+        .background(Color(.systemGray4))
         .navigationDestination(isPresented: $goToOCRView) {
             OCREditView(wordSelectViewModel: wordSelectViewModel)
         }

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -68,7 +68,7 @@ struct WordSelectView: View {
             .toolbarBackground(.blue.opacity(0.2), for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
             .navigationBarBackButtonHidden(true)
-            .navigationTitle("단어선택")
+            .navigationTitle("단어 선택")
             .navigationBarTitleDisplayMode(.inline)
         }
         .background(Color(.systemGray6))
@@ -84,10 +84,10 @@ struct WordSelectView: View {
                     .foregroundStyle(.white)
                     .padding()
                 VStack {
-                    Text("단어를 터치해 주세요.")
+                    Text("단어/영역을 선택해주세요.")
                         .font(.largeTitle)
                         .foregroundStyle(.white)
-                    Text("시험을 보고싶은 단어를 터치해주세요")
+                    Text("시험을 보고 싶은 단어/영역을 선택해주세요")
                         .foregroundStyle(.white)
                 }
                 .padding()

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -17,6 +17,7 @@ struct WordSelectView: View {
     
     @State var isSelectArea = true
     @State var noneOfWordSelected = true
+    var sessionNum: Int
     
     @ObservedObject var wordSelectViewModel: WordSelectViewModel
     
@@ -73,7 +74,7 @@ struct WordSelectView: View {
         }
         .background(Color(.systemGray4))
         .navigationDestination(isPresented: $goToOCRView) {
-            OCREditView(wordSelectViewModel: wordSelectViewModel)
+            OCREditView(sessionNum: sessionNum, wordSelectViewModel: wordSelectViewModel)
         }
         .popup(isPresented: $showingAlert) {
             HStack {

--- a/Blank/Blank/ViewModel/OverViewModel.swift
+++ b/Blank/Blank/ViewModel/OverViewModel.swift
@@ -213,30 +213,6 @@ class OverViewModel: ObservableObject {
         return pdfDocument.pageCount
     }
     
-    
-//    func generateImage() -> UIImage? {
-//        
-//        guard let page = pdfDocument.page(at: currentPage - 1) else {
-//            return nil
-//        }
-//        
-//        let pageRect = page.bounds(for: .mediaBox)
-//        let renderer = UIGraphicsImageRenderer(size: pageRect.size)
-//        
-//        let image = renderer.image { ctx in
-//            UIColor.white.set()
-//            ctx.fill(CGRect(origin: .zero, size: pageRect.size))
-//            
-//            ctx.cgContext.translateBy(x: 0, y: pageRect.size.height)
-//            ctx.cgContext.scaleBy(x: 1, y: -1)
-//            
-//            page.draw(with: .mediaBox, to: ctx.cgContext)
-//        }
-//        
-//        
-//        return image
-//    }
-    
     // PDF의 모든 페이지를 썸네일 이미지로 배열에 저장하는 메소드, 진행률도 표시
     func loadThumbnails() {
         isLoading = true

--- a/Blank/Blank/ViewModel/OverViewModel.swift
+++ b/Blank/Blank/ViewModel/OverViewModel.swift
@@ -213,29 +213,29 @@ class OverViewModel: ObservableObject {
         return pdfDocument.pageCount
     }
     
-    /// PDF의 현재 페이지를 이미지로 반환하는 메소드
-    func generateImage() -> UIImage? {
-        
-        guard let page = pdfDocument.page(at: currentPage - 1) else {
-            return nil
-        }
-        
-        let pageRect = page.bounds(for: .mediaBox)
-        let renderer = UIGraphicsImageRenderer(size: pageRect.size)
-        
-        let image = renderer.image { ctx in
-            UIColor.white.set()
-            ctx.fill(CGRect(origin: .zero, size: pageRect.size))
-            
-            ctx.cgContext.translateBy(x: 0, y: pageRect.size.height)
-            ctx.cgContext.scaleBy(x: 1, y: -1)
-            
-            page.draw(with: .mediaBox, to: ctx.cgContext)
-        }
-        
-        
-        return image
-    }
+    
+//    func generateImage() -> UIImage? {
+//        
+//        guard let page = pdfDocument.page(at: currentPage - 1) else {
+//            return nil
+//        }
+//        
+//        let pageRect = page.bounds(for: .mediaBox)
+//        let renderer = UIGraphicsImageRenderer(size: pageRect.size)
+//        
+//        let image = renderer.image { ctx in
+//            UIColor.white.set()
+//            ctx.fill(CGRect(origin: .zero, size: pageRect.size))
+//            
+//            ctx.cgContext.translateBy(x: 0, y: pageRect.size.height)
+//            ctx.cgContext.scaleBy(x: 1, y: -1)
+//            
+//            page.draw(with: .mediaBox, to: ctx.cgContext)
+//        }
+//        
+//        
+//        return image
+//    }
     
     // PDF의 모든 페이지를 썸네일 이미지로 배열에 저장하는 메소드, 진행률도 표시
     func loadThumbnails() {
@@ -289,66 +289,73 @@ class OverViewModel: ObservableObject {
         }
     }
     
+    /// PDF의 현재 페이지를 이미지로 반환하는 메소드
     func generateCurrentImage() {
-        guard let page = pdfDocument.page(at: currentPage - 1) else {
-            return
-        }
-        
-        // TODO: - 더 큰 해상도도 정확히 인식할 수 있어야 함
-        // 현재 가로 해상도 최대 600을 넘어가면 범위 어긋남
-        let maxWidth: CGFloat = 595 // 최대 크기를 더 늘릴 수 있다면 늘려보기
-        let maxHeight: CGFloat = maxWidth * 1.414
-        
-        let pageRect = page.bounds(for: .mediaBox)
-        let renderer = UIGraphicsImageRenderer(size: pageRect.size)
-        
-        let originalImage = renderer.image { imageContext in
-            UIColor.white.set()
-            
-            imageContext.fill(CGRect(origin: .zero, size: pageRect.size))
-            
-            imageContext.cgContext.translateBy(x: 0, y: pageRect.size.height)
-            imageContext.cgContext.scaleBy(x: 1, y: -1)
-            
-            page.draw(with: .mediaBox, to: imageContext.cgContext)
-        }
-        
-        // maxWidth보다 작으면 기존 이용
-        if originalImage.size.width <= maxWidth 
-            && originalImage.size.height / originalImage.size.width >= 1.41
-            && originalImage.size.height / originalImage.size.width <= 1.42 {
-            currentImage = originalImage
-            return
-        }
-        
-        let smallBoxSize: CGSize = .init(width: maxWidth, height: maxHeight)
-        let boxedRenderer = UIGraphicsImageRenderer(size: smallBoxSize)
-        let boxedImage = boxedRenderer.image { imageContext in
-            UIColor.white.set()
-            
-            imageContext.fill(CGRect(origin: .zero, size: smallBoxSize))
-            
-            if originalImage.size.height > originalImage.size.width {
-                let shrinkedWidth = min(maxWidth, maxHeight * (originalImage.size.width / originalImage.size.height))
-                let shrinkedHeight = shrinkedWidth * (originalImage.size.height / originalImage.size.width)
-                
-                let boxX = (smallBoxSize.width - shrinkedWidth) / 2
-                let boxY = (smallBoxSize.height - shrinkedHeight) / 2
-                let shrinkedSize = CGSize(width: shrinkedWidth, height: shrinkedHeight)
-                
-                originalImage.draw(in: .init(origin: .init(x: boxX, y: boxY), size: shrinkedSize))
-            } else {
-                let shrinkedHeight = min(maxHeight, maxWidth * (originalImage.size.height / originalImage.size.width))
-                let shrinkedWidth = shrinkedHeight * (originalImage.size.width / originalImage.size.height)
-                
-                let boxY = (smallBoxSize.height - shrinkedHeight) / 2
-                let boxX = (smallBoxSize.width - shrinkedWidth) / 2
-                let shrinkedSize = CGSize(width: shrinkedWidth, height: shrinkedHeight)
-                originalImage.draw(in: .init(origin: .init(x: boxX, y: boxY), size: shrinkedSize))
+            guard let page = pdfDocument.page(at: currentPage - 1) else {
+                return
             }
+            
+            // TODO: - 더 큰 해상도도 정확히 인식할 수 있어야 함
+            // 현재 가로 해상도 최대 600을 넘어가면 범위 어긋남
+            let maxWidth: CGFloat = 2380 // 최대 크기를 더 늘릴 수 있다면 늘려보기
+            let maxHeight: CGFloat = maxWidth * 1.414
+            
+            let rendererFormat = UIGraphicsImageRendererFormat()
+            rendererFormat.scale = 4.0 // 해상도를 더 높입니다.
+            rendererFormat.preferredRange = .extended // 더 넓은 색상 범위를 사용합니다.
+            
+            let pageRect = page.bounds(for: .mediaBox)
+    //        let renderer = UIGraphicsImageRenderer(size: pageRect.size)
+            let renderer = UIGraphicsImageRenderer(size: pageRect.size, format: rendererFormat)
+            
+            let originalImage = renderer.image { imageContext in
+                UIColor.white.set()
+                
+                imageContext.fill(CGRect(origin: .zero, size: pageRect.size))
+                
+                imageContext.cgContext.translateBy(x: 0, y: pageRect.size.height)
+                imageContext.cgContext.scaleBy(x: 1, y: -1)
+                
+                page.draw(with: .mediaBox, to: imageContext.cgContext)
+            }
+            
+            // maxWidth보다 작으면 기존 이용
+            if originalImage.size.width <= maxWidth
+                && originalImage.size.height / originalImage.size.width >= 1.41
+                && originalImage.size.height / originalImage.size.width <= 1.42 {
+                currentImage = originalImage
+                return
+            }
+            
+            let smallBoxSize: CGSize = .init(width: maxWidth, height: maxHeight)
+    //        let boxedRenderer = UIGraphicsImageRenderer(size: smallBoxSize)
+            let boxedRenderer = UIGraphicsImageRenderer(size: smallBoxSize, format: rendererFormat)
+            let boxedImage = boxedRenderer.image { imageContext in
+                UIColor.white.set()
+                
+                imageContext.fill(CGRect(origin: .zero, size: smallBoxSize))
+                
+                if originalImage.size.height > originalImage.size.width {
+                    let shrinkedWidth = min(maxWidth, maxHeight * (originalImage.size.width / originalImage.size.height))
+                    let shrinkedHeight = shrinkedWidth * (originalImage.size.height / originalImage.size.width)
+                    
+                    let boxX = (smallBoxSize.width - shrinkedWidth) / 2
+                    let boxY = (smallBoxSize.height - shrinkedHeight) / 2
+                    let shrinkedSize = CGSize(width: shrinkedWidth, height: shrinkedHeight)
+                    
+                    originalImage.draw(in: .init(origin: .init(x: boxX, y: boxY), size: shrinkedSize))
+                } else {
+                    let shrinkedHeight = min(maxHeight, maxWidth * (originalImage.size.height / originalImage.size.width))
+                    let shrinkedWidth = shrinkedHeight * (originalImage.size.width / originalImage.size.height)
+                    
+                    let boxY = (smallBoxSize.height - shrinkedHeight) / 2
+                    let boxX = (smallBoxSize.width - shrinkedWidth) / 2
+                    let shrinkedSize = CGSize(width: shrinkedWidth, height: shrinkedHeight)
+                    originalImage.draw(in: .init(origin: .init(x: boxX, y: boxY), size: shrinkedSize))
+                }
+            }
+            
+            currentImage = boxedImage
+            
         }
-        
-        currentImage = boxedImage
-        
-    }
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
- 알러트 내용 변경
- 네비게이션 뷰 타이틀 변경
- 이미지 화질 개선
- 배경색 전부 통일
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-21 at 17 08 22](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/38c066c3-1633-4967-896e-4a1475a1f439)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-21 at 17 08 17](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/9d0c7361-b279-4aaf-a652-1e22acf96e53)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-21 at 17 08 13](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/475250ac-067f-4b4f-add3-5679cb5cfb36)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-21 at 17 08 07](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/763c66b1-fc60-4761-8698-1bfef0272f74)

<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
