### PR TITLE
#152 design UI변경

### DIFF
--- a/Blank/Blank/View/Home/FolderThumbnailView.swift
+++ b/Blank/Blank/View/Home/FolderThumbnailView.swift
@@ -31,7 +31,7 @@ struct FolderThumbnailView: View {
                         .font(.title3)
                         .fontWeight(.bold)
                 } else {
-                    Text("이전 경로로")
+                    Text("이전으로")
                         .font(.title3)
                         .fontWeight(.bold)
                 }

--- a/Blank/Blank/View/Home/HomeView.swift
+++ b/Blank/Blank/View/Home/HomeView.swift
@@ -55,7 +55,7 @@ struct HomeView: View {
                 
                 ToolbarItem {
                     if mode == .normal {
-                        fileBtnNormalMode
+//                        fileBtnNormalMode
                     } else {
                         fileBtnEditMode
                     }
@@ -300,31 +300,29 @@ struct HomeView: View {
         
     }
     
-    private var fileBtnNormalMode: some View {
-        Menu {
-            Button {
-                showFilePicker = true
-            } label: {
-                Text("파일 보관함")
-            }
-            Button {
-                showImagePicker = true
-            } label: {
-                Text("사진 보관함")
-            }
-        } label: {
-            // Text("새 파일")
-            Text("파일 가져오기")
-        }
-    }
+//    private var fileBtnNormalMode: some View {
+//        Menu {
+//            Button {
+//                showFilePicker = true
+//            } label: {
+//                Text("파일 보관함")
+//            }
+//            Button {
+//                showImagePicker = true
+//            } label: {
+//                Text("사진 보관함")
+//            }
+//        } label: {
+//            // Text("새 파일")
+//            Text("파일 가져오기")
+//        }
+//        
+//    }
     
     private var fileBtnEditMode: some View {
         HStack {
             Button("이동") {
                 showMoveFiles.toggle()
-            }
-            Button("새 폴더") {
-                showCreateNewFolder.toggle()
             }
             
             Button {

--- a/Blank/Blank/View/Home/HomeView.swift
+++ b/Blank/Blank/View/Home/HomeView.swift
@@ -63,7 +63,7 @@ struct HomeView: View {
             }
             .toolbarBackground(Color.customToolbarBackgroundColor , for: .navigationBar)
             .toolbarBackground(.visible, for: .navigationBar)
-            .navigationTitle("홈")
+            .navigationBarTitle(homeViewModel.currentFolder?.fileName ?? "홈")
             .navigationBarTitleDisplayMode(.inline)
             .padding()
             .navigationBarBackButtonHidden(true)
@@ -299,25 +299,6 @@ struct HomeView: View {
 
         
     }
-    
-//    private var fileBtnNormalMode: some View {
-//        Menu {
-//            Button {
-//                showFilePicker = true
-//            } label: {
-//                Text("파일 보관함")
-//            }
-//            Button {
-//                showImagePicker = true
-//            } label: {
-//                Text("사진 보관함")
-//            }
-//        } label: {
-//            // Text("새 파일")
-//            Text("파일 가져오기")
-//        }
-//        
-//    }
     
     private var fileBtnEditMode: some View {
         HStack {

--- a/Blank/Blank/View/Home/HomeView.swift
+++ b/Blank/Blank/View/Home/HomeView.swift
@@ -264,17 +264,8 @@ struct HomeView: View {
     }
     
     private var addFileButton: some View {
-        Menu {
-            Button("새 폴더") {
-                showCreateNewFolder.toggle()
-            }
-            Button("새 pdf 추가") {
-                showFilePicker = true
-            }
-            Button("새 이미지 추가") {
-                showImagePicker = true
-            }
-        } label: {
+        
+        ZStack(alignment: .top) {
             VStack(spacing: 15) {
                 Spacer().frame(height: 5)
                 ZStack(alignment: .center) {
@@ -289,7 +280,23 @@ struct HomeView: View {
                 Text("신규..")
                 Spacer()
             }
+            Menu {
+                Button("새 폴더") {
+                    showCreateNewFolder.toggle()
+                }
+                Button("새 pdf 추가") {
+                    showFilePicker = true
+                }
+                Button("새 이미지 추가") {
+                    showImagePicker = true
+                }
+            } label: {
+                Rectangle()
+                    .fill(Color.clear)
+                    .frame(width: 110, height: 150)
+            }
         }
+
         
     }
     

--- a/Blank/Blank/View/Home/HomeView.swift
+++ b/Blank/Blank/View/Home/HomeView.swift
@@ -27,7 +27,7 @@ struct HomeView: View {
     @State private var isPopToHomeActive = false
     @State private var showCreateNewFolder = false
     @State private var showMoveFiles = false
-
+    
     @StateObject var homeViewModel: HomeViewModel = .init()
     
     // 새 PDF 생성 관련
@@ -50,7 +50,7 @@ struct HomeView: View {
             )
             .toolbar {
                 ToolbarItem(placement: .navigation) {
-                    editBtn
+                    editButton
                 }
                 
                 ToolbarItem {
@@ -165,13 +165,13 @@ struct HomeView: View {
     }
     
     private var thumbGridView: some View {
-        let item = GridItem(.adaptive(minimum: 120, maximum: 200), spacing: 30)
+        let item = GridItem(.adaptive(minimum: 120, maximum: 180), spacing: 30)
         let screenWidth = UIScreen.main.bounds.size.width
-        var columns = Array(repeating: item, count: 3)
-
+        var columns = Array(repeating: item, count: 4)
+        
         switch screenWidth {
-//        case 0..<745: //mini: 744
-//            columns = Array(repeating: item, count: 3)
+            //        case 0..<745: //mini: 744
+            //            columns = Array(repeating: item, count: 3)
         case 0..<834: // 10.2, 10.5
             columns = Array(repeating: item, count: 4)
         default: //11: 835   12
@@ -179,7 +179,7 @@ struct HomeView: View {
         }
         
         return ScrollView {
-            LazyVGrid(columns: columns, alignment: .center) {
+            LazyVGrid(columns: columns) {
                 if !homeViewModel.isLocatedInRootDirectory {
                     VStack {
                         FolderThumbnailView(isRoot: true)
@@ -188,6 +188,8 @@ struct HomeView: View {
                         homeViewModel.fetchFileListFromParentDirectory()
                     }
                 }
+                
+                addFileButton
                 
                 ForEach(homeViewModel.filteredFileList, id: \.id) { fileComponent in
                     if let file = fileComponent as? File {
@@ -208,8 +210,8 @@ struct HomeView: View {
     @ViewBuilder private func pdfThumbnail(_ file: File) -> some View {
         NavigationLink(
             destination: mode == .normal
-                       ? OverView(overViewModel: OverViewModel(currentFile: file))
-                       : nil
+            ? OverView(overViewModel: OverViewModel(currentFile: file))
+            : nil
         ) {
             ZStack(alignment:.topTrailing) {
                 PDFThumbnailView(file: file)
@@ -261,6 +263,36 @@ struct HomeView: View {
             .offset(x: -20, y: 10)
     }
     
+    private var addFileButton: some View {
+        Menu {
+            Button("새 폴더") {
+                showCreateNewFolder.toggle()
+            }
+            Button("새 pdf 추가") {
+                showFilePicker = true
+            }
+            Button("새 이미지 추가") {
+                showImagePicker = true
+            }
+        } label: {
+            VStack(spacing: 15) {
+                Spacer().frame(height: 5)
+                ZStack(alignment: .center) {
+                    Rectangle()
+                        .inset(by: 1.5)
+                        .stroke(Color.blue2, style: StrokeStyle(lineWidth: 3, dash:  [6,6]))
+                        .frame(width: 110, height: 150)
+                    Image(systemName: "plus.app")
+                        .font(.largeTitle)
+                        .foregroundColor(Color.blue2)
+                }
+                Text("신규..")
+                Spacer()
+            }
+        }
+        
+    }
+    
     private var fileBtnNormalMode: some View {
         Menu {
             Button {
@@ -297,7 +329,7 @@ struct HomeView: View {
         }
     }
     
-    private var editBtn: some View {
+    private var editButton: some View {
         Button {
             mode = mode.toggle
             if mode == .normal {
@@ -321,7 +353,7 @@ extension HomeView {
                 setAllowCreateNewPDF(false)
                 return
             }
-
+            
             try pdfData.write(to: targetDirectory.appendingPathComponent("\(newPDFFileName).pdf"))
             homeViewModel.fetchDocumentFileList()
             

--- a/Blank/Blank/View/Home/PDFThumbnailView.swift
+++ b/Blank/Blank/View/Home/PDFThumbnailView.swift
@@ -18,10 +18,12 @@ struct PDFThumbnailView: View {
                 .frame(height: 140)
             Spacer().frame(height: 15)
             Text("\((URL(fileURLWithPath: file.fileName).deletingPathExtension().lastPathComponent))")
-                .font(.title3)
+                .font(.headline)
                 .fontWeight(.bold)
             Text("전체 페이지수: \(file.totalPageCount)")
+                .font(.footnote)
             Text("시험 본 페이지: \(file.solvedPageCount)")
+                .font(.footnote)
             Spacer()
         }
         .padding()
@@ -42,5 +44,5 @@ extension PDFThumbnailView {
 }
 
 #Preview {
-    PDFThumbnailView(file: DUMMY_FILE)
+    HomeView()
 }

--- a/Blank/Blank/View/Home/SelectFolderView.swift
+++ b/Blank/Blank/View/Home/SelectFolderView.swift
@@ -17,12 +17,13 @@ struct SelectFolderView: View {
             List {
                 OutlineGroup(viewModel.directoryList, children: \.subfolder) { directory in
                     ZStack {
-                        Label(directory.fileName, systemImage: "folder.fill")
+                        Label(directory.fileName == "Documents" ? "홈" : directory.fileName, systemImage: "folder.fill")
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                             .background(viewModel.selectedFolder == directory ? .cyan.opacity(0.22) : .clear)
                             .onTapGesture {
                                 viewModel.selectedFolder = directory
                             }
+
                     }
                 }
             }

--- a/Blank/Blank/View/ImageView.swift
+++ b/Blank/Blank/View/ImageView.swift
@@ -95,10 +95,11 @@ struct ImageView: View {
                             let originalValue = targetWords[index].wordValue
                             let wroteValue = currentWritingWords[index].wordValue
                             
+                            
                             RoundedRectangle(cornerSize: .init(width: cornerRadiusSize, height: cornerRadiusSize))
                                 .path(in: adjustRect)
-                                .fill(isCorrect ? Color.correctColor : isAreaTouched[index, default: false] ? Color.flippedAreaColor : Color.wrongColor)
-                                .shadow(color: isCorrect ? .clear : .black.opacity(0.4), radius: 4, x: 0, y: 1)
+                                .fill(isCorrect ? Color.correctColor.shadow(.inner(color: .clear,radius: 0, y: 0)) : isAreaTouched[index, default: false] ? Color.flippedAreaColor.shadow(.inner(color: .black.opacity(0.5),radius: 2, y: -1)) : Color.wrongColor.shadow(.inner(color: .black.opacity(0.5),radius: 2, y: -1)))
+                                .shadow(color: isCorrect ? .clear : .black.opacity(0.7), radius: 0, x: 1, y: 2)
                                 .overlay(
                                     Text("\(isCorrect ? originalValue : isAreaTouched[index, default: false] ? originalValue : wroteValue)")
                                         .font(.system(size: adjustRect.height / fontSizeRatio, weight: .semibold))

--- a/Blank/Blank/View/OverView/OverVIewImageView.swift
+++ b/Blank/Blank/View/OverView/OverVIewImageView.swift
@@ -47,7 +47,7 @@ struct OverViewImageView: View {
                                                 .resizable()
                                                 .shadow(radius: 1)
                                                 .opacity(0.7)
-                                                .frame(width: proxy.size.width / 30, height: proxy.size.height / 40)
+                                                .frame(width: 50, height: 45)
                                                 .overlay(StatsText(stat: stat, proxy: proxy))
                                                 .position(x: adjustRect(key, in: proxy).midX, y: adjustRect(key, in: proxy).origin.y + 45 - zoomScale * 5)
                                         }
@@ -145,9 +145,9 @@ struct OverViewImageView: View {
         var body: some View {
             VStack(spacing: 0) {
                 Text("\(stat.correctSessionCount)/\(stat.totalSessionCount)")
-                    .font(.system(size: proxy.size.height / 100))
+                    .font(.system(size: 15))
                 Text("(\(stat.correctRate.percentageTextValue(decimalPlaces: 0)))")
-                    .font(.system(size: proxy.size.height / 150))
+                    .font(.system(size: 12))
             }
         }
     }

--- a/Blank/Blank/View/OverView/OverVIewImageView.swift
+++ b/Blank/Blank/View/OverView/OverVIewImageView.swift
@@ -128,9 +128,9 @@ struct OverViewImageView: View {
     // Rectangle 그리는 함수
     func drawRectangle(with key: CGRect, color: Color, in proxy: GeometryProxy) -> some View {
         Rectangle()
-            .fill(color)
+            .fill(color.shadow(.inner(color: .black.opacity(0.8),radius: 2, y: -1)))
             .cornerRadius(5)
-            .shadow(color: .black.opacity(0.4), radius: 4, x: 0, y: 1)
+            .shadow(color: .black.opacity(0.4), radius: 0, x: 1, y: 2)
             .frame(width: adjustRect(key, in: proxy).width,
                    height: adjustRect(key, in: proxy).height)
             .position(x: adjustRect(key, in: proxy).midX,

--- a/Blank/Blank/View/OverView/OverView.swift
+++ b/Blank/Blank/View/OverView/OverView.swift
@@ -467,7 +467,7 @@ struct OverView: View {
             showPopover = true
         } label: {
             HStack {
-                Text("\(overViewModel.currentFile.fileName)")
+                Text("\((URL(fileURLWithPath: overViewModel.currentFile.fileName).deletingPathExtension().lastPathComponent))")
                 Image(systemName: "chevron.down")
             }
             .foregroundColor(.black)

--- a/Blank/Blank/View/OverView/OverViewModalView.swift
+++ b/Blank/Blank/View/OverView/OverViewModalView.swift
@@ -21,7 +21,7 @@ struct OverViewModalView: View {
                         ForEach(overViewModel.thumbnails.indices, id: \.self) { index in
                             
                             // TODO: 기기에 따라 크기 조정
-                            VStack {
+                            VStack(spacing: 0) {
                                 Image(uiImage: overViewModel.thumbnails[index])
                                     .resizable()
                                     .scaledToFit()
@@ -36,12 +36,11 @@ struct OverViewModalView: View {
                                     Text("\(index+1)")
                                         .font(.caption)
                                         .fontWeight(.bold)
-                                    Spacer().frame(height: 0)
                                 }
                                 let pageNumberBasedOne = index + 1
                                 if overViewModel.lastSessionsOfPages[pageNumberBasedOne] == nil {
                                     Rectangle()
-                                        .frame(width: 80, height: 20)
+                                        .frame(width: 100, height: 30)
                                         .foregroundColor(Color(red: 0.46, green: 0.46, blue: 0.5).opacity(0.12))
                                         .cornerRadius(40)
                                         .overlay(
@@ -49,34 +48,25 @@ struct OverViewModalView: View {
                                             Text("-")
                                                 .tint(Color.blue)
                                         )
-                                    Text("[ - ]")
-                                    Spacer()
+                                    Text("시험을 봐주세요")
+                                        .font(.caption2)
                                     
-                                } else {
+                                } else if let info = overViewModel.lastSessionCorrectInfo(index: pageNumberBasedOne) {
                                     let lastSessionNumber = overViewModel.loadLastSessionNumber(index: index)
+//                                    let info = overViewModel.lastSessionCorrectInfo(index: pageNumberBasedOne)
                                     Rectangle()
-                                        .frame(width: 80, height: 20)
+                                        .frame(width: 100, height: 30)
                                         .foregroundColor(Color(red: 0.46, green: 0.46, blue: 0.5).opacity(0.12))
                                         .cornerRadius(40)
                                         .overlay(
-                                            Text("\(lastSessionNumber)회차")
+                                            Text("\(lastSessionNumber)회차(\(info.correctRate.percentageTextValue(decimalPlaces: 0)))")
                                                 .tint(Color.blue)
                                         )
-
-                                    if let info = overViewModel.lastSessionCorrectInfo(index: pageNumberBasedOne) {
-                                        VStack {
-                                            Text("정답률 : \(info.correctRate.percentageTextValue(decimalPlaces: 0))")
-                                            Text("문제 : \(info.totalCount)개")
-                                            Text("정답 : \(info.correctCount)개")
-                                        }
-                                    } else {
-                                        
-                                    }
-                                    
+                                    Text("문제:\(info.totalCount)개  정답:\(info.correctCount)개")
+                                        .font(.caption2)
                                     
                                 }
                             }
-                            .foregroundColor(.black)
                         }
                     }
                     .onAppear(perform:{

--- a/Blank/Blank/View/WordSelectView.swift
+++ b/Blank/Blank/View/WordSelectView.swift
@@ -85,10 +85,10 @@ struct WordSelectView: View {
                     .foregroundStyle(.white)
                     .padding()
                 VStack {
-                    Text("단어/영역을 선택해주세요.")
+                    Text("단어를 선택하거나 드래그해 주세요.")
                         .font(.largeTitle)
                         .foregroundStyle(.white)
-                    Text("시험을 보고 싶은 단어/영역을 선택해주세요")
+                    Text("시험을 보고 싶은 단어를 선택하거나 드래그해 주세요")
                         .foregroundStyle(.white)
                 }
                 .padding()

--- a/Blank/Blank/ViewModel/HomeViewModel.swift
+++ b/Blank/Blank/ViewModel/HomeViewModel.swift
@@ -12,6 +12,7 @@ class HomeViewModel: ObservableObject {
     @Published var selectedFileList: Set<File> = []
     @Published var selectedFolderList: Set<Folder> = []
     @Published var searchText = ""
+    @Published var currentFolder: Folder?
     
     @Published private(set) var currentDirectoryURL: URL?
     
@@ -52,6 +53,10 @@ class HomeViewModel: ObservableObject {
     func fetchDocumentFileList(from targetDirectoryURL: URL) {
         do {
             currentDirectoryURL = targetDirectoryURL
+
+            // 현재 폴더 설정
+            let folderName = targetDirectoryURL.lastPathComponent == "Documents" ? "홈" : targetDirectoryURL.lastPathComponent
+            currentFolder = Folder(id: UUID(), fileURL: targetDirectoryURL, fileName: folderName)
             
             let directoryContents = try FileManager.default.contentsOfDirectory(
                 at: targetDirectoryURL,
@@ -76,6 +81,7 @@ class HomeViewModel: ObservableObject {
             print(error)
         }
     }
+
     
     /// 파일 목록을 가져와서 [File] 형태로 저장
     func fetchDocumentFileList(_ subpath: String? = nil) {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!-- PR이 열린 이유와 작업 내용 -->
- 홈뷰의 파일의 텍스트 크기 조절
- 네비게이션 타이틀에 현재 폴더 이름이 뜨게 설정
- 오버뷰 모달뷰 데이터 표시 방법 변경
- 파일, 폴더 추가 버튼 재설정
- 폴더 디자인 변경
<!-- - 메인 홈 뷰의 UI를 전체 구현했습니다.(예시) -->


## 작업 사항
<!-- - 관리자용 대시보드 구현(예시) -->
![Simulator Screenshot - iPad mini (6th generation) - 2023-11-25 at 20 03 55](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/001d9dce-3ed6-49c0-bac7-cd16e8520c4c)
- 미니에서 보이는  텍스트 크기

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-25 at 19 59 38](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/910bfa9d-47d6-44bb-8131-3a86ad6733b7)

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-25 at 19 59 41](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/9cf37f6a-0dd3-42e9-a501-3e1c671c1bcb)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-11-25 at 20 02 08](https://github.com/DeveloperAcademy-POSTECH/MacC-Afternoon-Team11-FoursTech-Blank/assets/116425551/ce2ad666-cfb1-4e17-bc4b-399ec8e05690)



<!-- - 관리자용 권한 수정 버튼 추가(예시) -->

## 주요 로직(Optional)
```diff
- print("변경 전")
+ print("변경 후")
```
